### PR TITLE
feat(routing): update routing to use createBrowserRouter, add layouts for header and footers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,20 @@
-import { Routes, Route, BrowserRouter as Router } from 'react-router-dom';
+import { Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from 'react-router-dom';
 import './index.css';
 import { About, FAQ, Home } from './components/pages';
-import { NavBar } from './components/layout';
+import { Layout } from './components/layout';
 
 function App() {
-  return (
-    <Router>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/faq" element={<FAQ />} />
-        <Route path="*" element={<Home />} />
-      </Routes>
-    </Router>
+  const router = createBrowserRouter(
+    createRoutesFromElements(
+      <Route element={<Layout/>}>
+        <Route index={true} element={<Home />} />
+        <Route path="about" element={<About />} />
+        <Route path="faq" element={<FAQ />} />
+      </Route>
+    )
   );
+
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route element={<Layout/>}>
-        <Route index={true} element={<Home />} />
+        <Route index element={<Home />} />
         <Route path="about" element={<About />} />
         <Route path="faq" element={<FAQ />} />
       </Route>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 function Footer() {
   return (
-    <div style={{ 'justify-content': 'center' }}>
+    <div>
       <span>Copyright ar.io 2022</span>
     </div>
   );

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -1,0 +1,9 @@
+function Footer() {
+  return (
+    <div style={{ 'justify-content': 'center' }}>
+      <span>Copyright ar.io 2022</span>
+    </div>
+  );
+}
+
+export default Footer;

--- a/src/components/layout/Footer/styles.css
+++ b/src/components/layout/Footer/styles.css
@@ -1,0 +1,3 @@
+.footer {
+  height: 100px;
+}

--- a/src/components/layout/Footer/styles.css
+++ b/src/components/layout/Footer/styles.css
@@ -1,3 +1,0 @@
-.footer {
-  height: 100px;
-}

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,8 +1,8 @@
 import NavBar from '../Navbar/Navbar';
 import Footer from '../Footer/Footer';
-import './styles.css'; // will be injected into the page
+import './styles.css';
 
-function Layout({ children }) {
+function Layout({ children }: { children: any }) {
   return (
     <>
       <div className="header">

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,0 +1,21 @@
+import NavBar from '../Navbar/Navbar';
+import Footer from '../Footer/Footer';
+import './styles.css'; // will be injected into the page
+
+function Layout({ children }) {
+  return (
+    <>
+      <div className="header">
+        <NavBar />
+      </div>
+      <div className="body">
+        <div className="container">{children}</div>
+        <div className="footer">
+          <Footer />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Layout;

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,15 +1,18 @@
+import { Outlet } from 'react-router-dom';
 import NavBar from '../Navbar/Navbar';
 import Footer from '../Footer/Footer';
 import './styles.css';
 
-function Layout({ children }: { children: any }) {
+function Layout() {
   return (
     <>
       <div className="header">
         <NavBar />
       </div>
       <div className="body">
-        <div className="container">{children}</div>
+        <div className="container">
+            <Outlet />
+        </div>
         <div className="footer">
           <Footer />
         </div>

--- a/src/components/layout/Layout/styles.css
+++ b/src/components/layout/Layout/styles.css
@@ -1,0 +1,25 @@
+.header {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  min-height: 10vh;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  min-height: 90vh;
+}
+
+.container {
+  flex: 1;
+}
+
+.footer {
+  display: flex;
+  flex-direction: row;
+  height: 100px;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -3,12 +3,10 @@ import logo from '../../../../assets/images/logo/winston-white.gif';
 
 function NavBar() {
   return (
-    <div className="navBar">
-      <div className="navBarItemContainer">
-        <Link to="/" className="brandLogo">
-          <img src={logo} width={90} height={90} />
-        </Link>
-      </div>
+    <div className="navBarItemContainer">
+      <Link to="/" className="brandLogo">
+        <img src={logo} width={90} height={90} />
+      </Link>
     </div>
   );
 }

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,2 @@
-import NavBar from './Navbar/Navbar';
-
-export { NavBar };
+import Layout from './Layout/Layout';
+export { Layout };

--- a/src/components/pages/About/About.tsx
+++ b/src/components/pages/About/About.tsx
@@ -1,7 +1,7 @@
 import './styles.css';
 
 function About() {
-  return <div className="about"></div>;
+  return <div className="about">About</div>;
 }
 
 export default About;

--- a/src/components/pages/About/About.tsx
+++ b/src/components/pages/About/About.tsx
@@ -1,3 +1,5 @@
+import './styles.css';
+
 function About() {
   return <div className="about"></div>;
 }

--- a/src/components/pages/About/__tests__/About.test.tsx
+++ b/src/components/pages/About/__tests__/About.test.tsx
@@ -5,8 +5,6 @@ describe('About', () => {
   afterEach(cleanup);
 
   test('render About', () => {
-    render(
-        <About />
-    );
+    render(<About />);
   });
 });

--- a/src/components/pages/FAQ/FAQ.tsx
+++ b/src/components/pages/FAQ/FAQ.tsx
@@ -1,3 +1,5 @@
+import './styles.css';
+
 function FAQ() {
   return <div className="faq"></div>;
 }

--- a/src/components/pages/FAQ/FAQ.tsx
+++ b/src/components/pages/FAQ/FAQ.tsx
@@ -1,7 +1,7 @@
 import './styles.css';
 
 function FAQ() {
-  return <div className="faq"></div>;
+  return <div className="faq">FAQ</div>;
 }
 
 export default FAQ;

--- a/src/components/pages/FAQ/__tests__/FAQ.test.tsx
+++ b/src/components/pages/FAQ/__tests__/FAQ.test.tsx
@@ -5,8 +5,6 @@ describe('FAQ', () => {
   afterEach(cleanup);
 
   test('render FAQ', () => {
-    render(
-        <FAQ />
-    );
+    render(<FAQ />);
   });
 });

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -1,8 +1,7 @@
 import './styles.css';
-import React from 'react';
 
 function Home() {
-  return <div className="home"></div>;
+  return <div className="home">Home</div>;
 }
 
 export default Home;

--- a/src/components/pages/Home/__tests__/Home.test.tsx
+++ b/src/components/pages/Home/__tests__/Home.test.tsx
@@ -5,8 +5,6 @@ describe('Home', () => {
   afterEach(cleanup);
 
   test('render Home', () => {
-    render(
-        <Home />
-    );
+    render(<Home />);
   });
 });


### PR DESCRIPTION
### Details
- Moves us to using `createBrowserRouter` in place of `BrowserRouter`
- Adds `Layout` component which wraps every page, to include header and footer
- Imports `styles.css` to pages that were not importing them before