### PR TITLE
fix: handle click events in connect modal

### DIFF
--- a/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
+++ b/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import ConnectWalletModal from '../../../modals/ConnectWalletModal/ConnectWalletModal';
 import './styles.css';
 
 function ConnectButton(): JSX.Element {
+  const modalRef = useRef(null);
   const [showModal, setShowModal] = useState(false);
 
   return (
@@ -14,7 +15,9 @@ function ConnectButton(): JSX.Element {
       >
         Connect
       </button>
-      {showModal && <ConnectWalletModal setShowModal={setShowModal} />}
+      {showModal && (
+        <ConnectWalletModal setShowModal={setShowModal} />
+      )}
     </>
   );
 }

--- a/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
+++ b/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import ConnectWalletModal from '../../../modals/ConnectWalletModal/ConnectWalletModal';
 import './styles.css';
 
 function ConnectButton(): JSX.Element {
-  const modalRef = useRef(null);
   const [showModal, setShowModal] = useState(false);
 
   return (
@@ -15,9 +14,7 @@ function ConnectButton(): JSX.Element {
       >
         Connect
       </button>
-      {showModal && (
-        <ConnectWalletModal setShowModal={setShowModal} />
-      )}
+      {showModal && <ConnectWalletModal setShowModal={setShowModal} />}
     </>
   );
 }

--- a/src/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { ConnectWalletModalProps } from '../../../types';
 import {
@@ -9,21 +9,31 @@ import {
 } from '../../icons';
 import './styles.css';
 
-function ConnectWalletModal({
-  setShowModal,
-}: ConnectWalletModalProps): JSX.Element {
-  const [clickOut, setClickOut] = useState(false);
+function ConnectWalletModal(props: ConnectWalletModalProps): JSX.Element {
+  const { setShowModal } = props;
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (!modalRef || !modalRef.current) {
+      return;
+    }
+    // Bind the event listener
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [modalRef]);
+
+  function handleClickOutside(event: MouseEvent) {
+    if (modalRef.current && modalRef.current === event.target) {
+      setShowModal(false);
+    }
+  }
 
   return (
-    <button
-      className="modalContainer"
-      onClick={() => clickOut && setShowModal(false)}
-    >
-      <div
-        className="connectWalletModal"
-        onMouseLeave={() => setClickOut(true)}
-        onMouseEnter={() => setClickOut(false)}
-      >
+    <div className="modalContainer" ref={modalRef}>
+      <div className="connectWalletModal">
         <p
           className="sectionHeader"
           style={{ marginBottom: '1em', fontFamily: 'Rubik-Bold' }}
@@ -62,7 +72,7 @@ function ConnectWalletModal({
           </a>
         </span>
       </div>
-    </button>
+    </div>
   );
 }
 export default ConnectWalletModal;

--- a/src/components/modals/ConnectWalletModal/styles.css
+++ b/src/components/modals/ConnectWalletModal/styles.css
@@ -8,6 +8,7 @@
   height: 100%;
   top: 0;
   left: 0;
+  z-index: 100;
 }
 .modalCloseButton {
   display: flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
 export type ArNSDomains = { [x: string]: ArweaveTransactionId };
 
@@ -52,8 +53,10 @@ export type SearchBarFooterProps = {
 };
 
 export type ConnectWalletModalProps = {
+  ref?: React.RefObject<unknown>;
   setShowModal: Dispatch<SetStateAction<boolean>>;
 };
+
 export type TierCardProps = {
   tier: number;
   setTier: Dispatch<SetStateAction<number>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React from 'react';
 
 export type ArNSDomains = { [x: string]: ArweaveTransactionId };
 
@@ -53,7 +52,6 @@ export type SearchBarFooterProps = {
 };
 
 export type ConnectWalletModalProps = {
-  ref?: React.RefObject<unknown>;
   setShowModal: Dispatch<SetStateAction<boolean>>;
 };
 


### PR DESCRIPTION
### Details
- handles clicking outside the primary connect modal to close the entire div using React.RefObject