### PR TITLE
feat(manage): migrate to react table component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.1.3",
         "buffer": "^6.0.3",
         "lodash": "^4.17.21",
+        "rc-table": "^7.30.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.6.0",
@@ -1800,12 +1801,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
-      "dev": true,
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2800,6 +2800,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.3.0.tgz",
+      "integrity": "sha512-6QdaCJ7Wn5UZLJs15IEfqy4Ru3OaL5ctqpQYWd5rlfV9wwzrzdt6+kgAQZV/qdB0MUPN4nhyBfRembQCIvBf+w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -5137,6 +5150,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -11821,6 +11839,58 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/rc-resize-observer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.1.tgz",
+      "integrity": "sha512-g53PnWLeVOmt4XWkt2x+QlIdf/PhJSd7JqHhtMrUY370e7wJ+kxbgXicYqvENUcgFiiOiMCd07YsC2GNsoSbnA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.27.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-table": {
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.30.3.tgz",
+      "integrity": "sha512-PHe+lZKwPo3qui5j79m54vKu8b4hebk04x+4Hy65NvwUU3+NNFGS5FZpylXQMkueMnE8hgh22ZuScQDkCtzQFQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.3.0",
+        "classnames": "^2.2.5",
+        "rc-resize-observer": "^1.1.0",
+        "rc-util": "^5.27.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.27.1.tgz",
+      "integrity": "sha512-PsjHA+f+KBCz+YTZxrl3ukJU5RoNKoe3KSNMh0xGiISbR67NaM9E9BiMjCwxa3AcCUOg/rZ+V0ZKLSimAA+e3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -12060,10 +12130,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -12177,6 +12246,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -14968,12 +15042,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
-      "dev": true,
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -15741,6 +15814,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@rc-component/context": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.3.0.tgz",
+      "integrity": "sha512-6QdaCJ7Wn5UZLJs15IEfqy4Ru3OaL5ctqpQYWd5rlfV9wwzrzdt6+kgAQZV/qdB0MUPN4nhyBfRembQCIvBf+w==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
       }
     },
     "@remix-run/router": {
@@ -17505,6 +17587,11 @@
         "napi-macros": "~2.0.0",
         "node-gyp-build": "^4.3.0"
       }
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -22412,6 +22499,45 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "rc-resize-observer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.1.tgz",
+      "integrity": "sha512-g53PnWLeVOmt4XWkt2x+QlIdf/PhJSd7JqHhtMrUY370e7wJ+kxbgXicYqvENUcgFiiOiMCd07YsC2GNsoSbnA==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.27.0",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "rc-table": {
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.30.3.tgz",
+      "integrity": "sha512-PHe+lZKwPo3qui5j79m54vKu8b4hebk04x+4Hy65NvwUU3+NNFGS5FZpylXQMkueMnE8hgh22ZuScQDkCtzQFQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.3.0",
+        "classnames": "^2.2.5",
+        "rc-resize-observer": "^1.1.0",
+        "rc-util": "^5.27.1"
+      }
+    },
+    "rc-util": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.27.1.tgz",
+      "integrity": "sha512-PsjHA+f+KBCz+YTZxrl3ukJU5RoNKoe3KSNMh0xGiISbR67NaM9E9BiMjCwxa3AcCUOg/rZ+V0ZKLSimAA+e3w==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -22604,10 +22730,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -22696,6 +22821,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.1.3",
     "buffer": "^6.0.3",
     "lodash": "^4.17.21",
+    "rc-table": "^7.30.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",

--- a/src/components/cards/AntCard/AntCard.tsx
+++ b/src/components/cards/AntCard/AntCard.tsx
@@ -9,7 +9,7 @@ import CopyTextButton from '../../inputs/buttons/CopyTextButton/CopyTextButton';
 import { Loader } from '../../layout';
 import './styles.css';
 
-const ANT_DETAIL_MAPPINGS: { [x: string]: string } = {
+export const ANT_DETAIL_MAPPINGS: { [x: string]: string } = {
   name: 'Nickname',
   id: 'ANT Contract ID',
   leaseDuration: 'Lease Duration',
@@ -17,14 +17,14 @@ const ANT_DETAIL_MAPPINGS: { [x: string]: string } = {
   controller: 'Controllers',
 };
 
-function mapKeyToAttribute(key: string) {
+export function mapKeyToAttribute(key: string) {
   if (ANT_DETAIL_MAPPINGS[key]) {
     return ANT_DETAIL_MAPPINGS[key];
   }
   return startCase(key);
 }
 
-const PRIMARY_DETAILS: string[] = [
+export const PRIMARY_DETAILS: string[] = [
   'id',
   'domain',
   'owner',
@@ -33,7 +33,7 @@ const PRIMARY_DETAILS: string[] = [
   'nickname',
 ].map((i) => mapKeyToAttribute(i));
 
-const DEFAULT_ATTRIBUTES = {
+export const DEFAULT_ATTRIBUTES = {
   ttlSeconds: 60 * 60,
   leaseDuration: 'N/A',
   maxSubdomains: 100,

--- a/src/components/inputs/buttons/CopyTextButton/CopyTextButton.tsx
+++ b/src/components/inputs/buttons/CopyTextButton/CopyTextButton.tsx
@@ -31,9 +31,7 @@ function CopyTextButton({
     <div className="flex" style={{ position, ...wrapperStyle }}>
       <button
         className="flex flex-space-between button"
-        style={{
-          ...wrapperStyle,
-        }}
+        style={{ ...wrapperStyle, cursor: 'pointer' }}
         onClick={async () => {
           await handleCopy();
         }}

--- a/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
+++ b/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
@@ -17,17 +17,12 @@ function ManageAssetButtons({
 
   return (
     <>
-      <div
-        className="flex-row center"
-        style={{ gap: '.5em', width: 'fit-content' }}
-      >
-        <button className="assets-see-more-button center hover">
-          See More
-        </button>
+      <div className="flex-row center" style={{ gap: '0.5em' }}>
+        <button className="assets-see-more-button">See More</button>
 
         {!isMobile ? (
           <button
-            className="assets-manage-button center hover"
+            className="assets-manage-button"
             onClick={() => setShowModal(true)}
           >
             Manage

--- a/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
+++ b/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
@@ -8,10 +8,12 @@ function ManageAssetButtons({
   // eslint-disable-next-line
   assetType,
   setShowModal,
+  disabled = true,
 }: {
   asset: ArweaveTransactionID | string;
   assetType: ASSET_TYPES;
   setShowModal: (show: boolean) => void;
+  disabled: boolean;
 }) {
   const isMobile = useIsMobile();
 
@@ -24,6 +26,7 @@ function ManageAssetButtons({
           <button
             className="assets-manage-button"
             onClick={() => setShowModal(true)}
+            disabled={disabled}
           >
             Manage
           </button>

--- a/src/components/layout/TransactionStatus/TransactionStatus.tsx
+++ b/src/components/layout/TransactionStatus/TransactionStatus.tsx
@@ -3,8 +3,10 @@ import { AlertCircle, AlertTriangleIcon, CircleCheck } from '../../icons';
 
 function TransactionStatus({
   confirmations,
+  wrapperStyle,
 }: {
   confirmations: number;
+  wrapperStyle?: any;
 }): JSX.Element {
   const isMobile = useIsMobile();
 
@@ -27,7 +29,10 @@ function TransactionStatus({
     }
   }
   return (
-    <span className="text white bold center">
+    <span
+      className="text white bold"
+      style={{ alignItems: 'center', ...wrapperStyle }}
+    >
       {getStatusIcon(confirmations)}&nbsp;
       {!isMobile ? `${confirmations} / 50` : <></>}
     </span>

--- a/src/components/layout/tables/AntRow/AntRow.tsx
+++ b/src/components/layout/tables/AntRow/AntRow.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useIsMobile } from '../../../../hooks';
 import { useGlobalState } from '../../../../state/contexts/GlobalState';
-import { ArweaveTransactionID } from '../../../../types';
+import { ArNSContractState, ArweaveTransactionID } from '../../../../types';
 import { ASSET_TYPES } from '../../../../types';
 import { RefreshAlertIcon } from '../../../icons';
 import CopyTextButton from '../../../inputs/buttons/CopyTextButton/CopyTextButton';
@@ -240,10 +240,15 @@ function AntRow({
       {showManageModal && confirmations ? (
         <ManageAntModal
           setShowModal={setShowModal}
-          state={antState}
+          antDetails={{
+            id: antId.toString(),
+            name: antState.name,
+            target: targetId ?? 'N/A',
+            status: +confirmations,
+            key: 0,
+            state: antState as ArNSContractState,
+          }}
           contractId={antId}
-          targetId={targetId}
-          confirmations={confirmations}
         />
       ) : (
         <></>

--- a/src/components/layout/tables/AntRow/AntRow.tsx
+++ b/src/components/layout/tables/AntRow/AntRow.tsx
@@ -232,6 +232,7 @@ function AntRow({
                 asset={antId}
                 assetType={ASSET_TYPES.ANT}
                 setShowModal={setShowModal}
+                disabled={!antState && !confirmations}
               />
             </td>
           )}

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -150,26 +150,7 @@ function ManageAntModal({
         >
           <span className="flex bold text-medium white">
             <NotebookIcon width={25} height={25} fill={'var(--text-white)'} />
-            &nbsp;Manage ANT:&nbsp;
-            <span className="flex">
-              <CopyTextButton
-                displayText={
-                  isMobile
-                    ? `${contractId.toString().slice(0, 10)}...${contractId
-                        .toString()
-                        .slice(-10)}`
-                    : contractId.toString()
-                }
-                copyText={contractId.toString()}
-                size={24}
-                wrapperStyle={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  textColor: 'var(--bright-white)',
-                }}
-              />
-            </span>
+            Manage ANT
           </span>
         </div>
         <Table

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -232,7 +232,12 @@ function ManageAntModal({
                   return (
                     <>
                       {editingField !== row.attribute ? (
-                        <button onClick={() => setEditingField(row.attribute)}>
+                        <button
+                          onClick={() => {
+                            setEditingField(row.attribute);
+                            setModifiedValue(row.value);
+                          }}
+                        >
                           <PencilIcon
                             style={{ width: '24', height: '24', fill: 'white' }}
                           />
@@ -250,6 +255,7 @@ function ManageAntModal({
                             );
                             // TODO: write contract interaction
                             setEditingField(undefined);
+                            setModifiedValue(undefined);
                           }}
                         >
                           Save

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -9,7 +9,6 @@ import {
   mapKeyToAttribute,
 } from '../../cards/AntCard/AntCard';
 import { NotebookIcon, PencilIcon } from '../../icons';
-import CopyTextButton from '../../inputs/buttons/CopyTextButton/CopyTextButton';
 import TransactionStatus from '../../layout/TransactionStatus/TransactionStatus';
 
 const EDITABLE_FIELDS = [

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -174,7 +174,9 @@ function ManageAntModal({
         </div>
         <Table
           showHeader={false}
-          rowClassName={'table-row'}
+          onRow={(row) => ({
+            className: row.attribute === editingField ? 'active-row' : '',
+          })}
           columns={[
             {
               title: '',
@@ -257,6 +259,10 @@ function ManageAntModal({
                       ) : (
                         <button
                           className="assets-manage-button"
+                          style={{
+                            backgroundColor: 'var(--accent)',
+                            borderColor: 'var(--accent)',
+                          }}
                           onClick={() => {
                             alert(
                               `Writing contract interaction...${modifiedValue}`,

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -192,6 +192,7 @@ function ManageAntModal({
                         id={row.attribute}
                         style={{
                           width: '80%',
+                          fontSize: '16px',
                           background:
                             editingField === row.attribute
                               ? 'white'

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -138,7 +138,7 @@ function ManageAntModal({
     >
       <div
         className="flex-column"
-        style={{ margin: '10%', width: '50%', minWidth: '350px', gap: '0.5em' }}
+        style={{ margin: '10%', minWidth: '350px', gap: '0.5em' }}
       >
         <div
           className="flex"

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -197,7 +197,11 @@ function ManageAntModal({
                             editingField === row.attribute
                               ? 'white'
                               : 'transparent',
-                          border: 'none',
+                          border:
+                            editingField === row.attribute
+                              ? '2px solid #E0E0E0'
+                              : 'none',
+                          borderRadius: '2px',
                           color:
                             editingField === row.attribute ? 'black' : 'white',
                           padding:

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -12,15 +12,35 @@ import { NotebookIcon, PencilIcon } from '../../icons';
 import CopyTextButton from '../../inputs/buttons/CopyTextButton/CopyTextButton';
 import TransactionStatus from '../../layout/TransactionStatus/TransactionStatus';
 
-enum EDITABLE_FIELDS {
-  NAME = 'name',
-  TICKER = 'ticker',
-  TARGET = 'targetID',
-  TTL = 'ttlSeconds',
-  CONTROLLER = 'controller',
-}
+// enum EDITABLE_FIELDS {
+//   NAME = 'name',
+//   TICKER = 'ticker',
+//   TARGET = 'targetID',
+//   TTL = 'ttlSeconds',
+//   CONTROLLER = 'controller',
+// }
 
-const ACTIONABLE_FIELDS = {
+const EDITABLE_FIELDS = [
+  'name',
+  'ticker',
+  'targetID',
+  'ttlSeconds',
+  'controller',
+];
+
+type ManageAntRow = {
+  attribute: string;
+  value: string;
+  action: any;
+  key: number;
+};
+
+const ACTIONABLE_FIELDS: {
+  [x: string]: {
+    fn: () => void;
+    title: string;
+  };
+} = {
   owner: {
     fn: () => alert('this feature is coming soon...'),
     title: 'Transfer',
@@ -83,8 +103,8 @@ function ManageAntModal({
     const names = getAssociatedNames(id);
     //  eslint-disable-next-line
     const { state, key, ...otherDetails } = antDetails;
-    const consolidatedDetails = {
-      status: antDetails.status ?? 'N/A',
+    const consolidatedDetails: ManageAntRow & any = {
+      status: antDetails.status ?? 0,
       associatedNames: !names.length ? 'N/A' : names.join(', '),
       name: antDetails.name ?? 'N/A',
       ticker: state.ticker ?? 'N/A',
@@ -99,19 +119,10 @@ function ManageAntModal({
     };
 
     const rows = Object.keys(consolidatedDetails).reduce(
-      (
-        details: {
-          attribute: string;
-          value: string;
-          action: any;
-          key: number;
-        }[],
-        attribute: string,
-        index: number,
-      ) => {
+      (details: ManageAntRow[], attribute: string, index: number) => {
         const detail = {
           attribute,
-          value: consolidatedDetails[attribute],
+          value: consolidatedDetails[attribute as keyof ManageAntRow],
           action: Object.values(EDITABLE_FIELDS).includes(attribute) ? (
             <button onClick={() => setEditingField(attribute)}>
               <PencilIcon

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -157,6 +157,7 @@ function ManageAntModal({
           onRow={(row) => ({
             className: row.attribute === editingField ? 'active-row' : '',
           })}
+          scroll={{ x: true }}
           columns={[
             {
               title: '',

--- a/src/components/modals/ManageAntModal/ManageAntModal.tsx
+++ b/src/components/modals/ManageAntModal/ManageAntModal.tsx
@@ -139,7 +139,7 @@ function ManageAntModal({
     >
       <div
         className="flex-column"
-        style={{ margin: '10%', width: '50%', minWidth: '350px' }}
+        style={{ margin: '10%', width: '50%', minWidth: '350px', gap: '0.5em' }}
       >
         <div
           className="flex"
@@ -167,7 +167,7 @@ function ManageAntModal({
               width: isMobile ? '0px' : '30%',
               className: 'white',
               render: (value: string) => {
-                return mapKeyToAttribute(value);
+                return `${mapKeyToAttribute(value)}:`;
               },
             },
             {

--- a/src/components/pages/Manage/Manage.tsx
+++ b/src/components/pages/Manage/Manage.tsx
@@ -1,15 +1,12 @@
-import Table from 'rc-table';
 import { useEffect, useState } from 'react';
 
-import { useIsMobile, useWalletAddress } from '../../../hooks';
+import { useWalletAddress } from '../../../hooks';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
-import { ASSET_TYPES, ArweaveTransactionID } from '../../../types';
+import { ArweaveTransactionID } from '../../../types';
 import { TABLE_TYPES } from '../../../types';
 import { CodeSandboxIcon } from '../../icons';
-import CopyTextButton from '../../inputs/buttons/CopyTextButton/CopyTextButton';
-import ManageAssetButtons from '../../inputs/buttons/ManageAssetButtons/ManageAssetButtons';
 import { Loader } from '../../layout';
-import TransactionStatus from '../../layout/TransactionStatus/TransactionStatus';
+import { AntTable } from '../../layout/tables';
 import './styles.css';
 
 function Manage() {
@@ -17,64 +14,34 @@ function Manage() {
   const { walletAddress } = useWalletAddress();
 
   const [tableType, setTableType] = useState(TABLE_TYPES.ANT); // ant_table or name_table
-  const [sortAscending, setSortOrder] = useState(true);
-  const isMobile = useIsMobile();
+
   const [isLoading, setIsLoading] = useState(false);
+  const [walletANTs, setWalletANTs] = useState<ArweaveTransactionID[]>([]);
   const [cursor] = useState<string | undefined>();
   const [reload, setReload] = useState(false);
-  const [rows, setRows] = useState<
-    {
-      name: string;
-      id: string;
-      target: string;
-      status: number;
-      key: number;
-    }[]
-  >([]);
 
   useEffect(() => {
-    // todo: move this to a separate function to manage error state and poll for new ants to concat them to the state.
+    // todo: move this to a seperate function to manage error state and poll for new ants to concat them to the state.
     // todo: load imported ants and names first
     if (walletAddress) {
       setIsLoading(true);
-      fetchAntRows(walletAddress).finally(() => setIsLoading(false));
+      arweaveDataProvider
+        .getContractsForWallet(
+          arnsSourceContract.approvedANTSourceCodeTxs,
+          walletAddress,
+          cursor,
+        )
+        .then(({ ids }: { ids: ArweaveTransactionID[]; cursor?: string }) => {
+          setWalletANTs(ids);
+          // don't set cursor for now
+        })
+        .finally(() => setIsLoading(false))
+        .catch((error: Error) => {
+          console.error(error);
+          setIsLoading(false);
+        });
     }
   }, [walletAddress, reload]);
-
-  async function fetchAntRows(address: ArweaveTransactionID) {
-    const { ids } = await arweaveDataProvider.getContractsForWallet(
-      arnsSourceContract.approvedANTSourceCodeTxs,
-      address,
-      cursor,
-    );
-    // TODO: make this row a type
-    const fetchedRows: {
-      name: string;
-      id: string;
-      target: string;
-      status: number;
-      key: number;
-    }[] = [];
-    for (const [index, id] of ids.entries()) {
-      const [contractState, confirmations] = await Promise.all([
-        arweaveDataProvider.getContractState(id),
-        arweaveDataProvider.getTransactionStatus(id),
-      ]);
-      const rowData = {
-        name: contractState.name ?? 'N/A',
-        id: id.toString(),
-        target:
-          contractState.records['@']?.transactionId ??
-          contractState.records['@'],
-        status: confirmations ?? 0,
-        key: index,
-      };
-      fetchedRows.push(rowData);
-    }
-    // sort by name by default
-    fetchedRows.sort((a, b) => a.name.localeCompare(b.name));
-    setRows(fetchedRows);
-  }
 
   return (
     <div className="page">
@@ -110,146 +77,7 @@ function Manage() {
               <Loader size={80} />
             </div>
           ) : (
-            <Table
-              rowClassName={'table-row'}
-              columns={[
-                {
-                  title: 'Nickname',
-                  dataIndex: 'name',
-                  key: 'name',
-                  align: 'left',
-                  width: '10%',
-                  className: 'white',
-                  ellipsis: true,
-                  onHeaderCell: () => {
-                    return {
-                      onClick: () => {
-                        rows.sort((a, b) =>
-                          // by default we sort by name
-                          !sortAscending
-                            ? a.name.localeCompare(b.name)
-                            : b.name.localeCompare(a.name),
-                        );
-                        // forces update of rows
-                        setRows([...rows]);
-                        setSortOrder(!sortAscending);
-                      },
-                    };
-                  },
-                },
-                {
-                  title: 'Contract ID',
-                  dataIndex: 'id',
-                  key: 'id',
-                  align: 'center',
-                  width: '35%',
-                  className: 'white',
-                  ellipsis: true,
-                  render: (val) => (
-                    <CopyTextButton
-                      displayText={`${val.slice(
-                        0,
-                        isMobile ? 2 : 6,
-                      )}...${val.slice(isMobile ? -2 : -6)}`}
-                      copyText={val}
-                      size={24}
-                      wrapperStyle={{
-                        position: 'unset',
-                        justifyContent: 'center',
-                      }}
-                    />
-                  ),
-                  onHeaderCell: () => {
-                    return {
-                      onClick: () => {
-                        rows.sort((a, b) =>
-                          sortAscending
-                            ? a.id.localeCompare(b.id)
-                            : b.id.localeCompare(a.id),
-                        );
-                        // forces update of rows
-                        setRows([...rows]);
-                        setSortOrder(!sortAscending);
-                      },
-                    };
-                  },
-                },
-                {
-                  title: 'Target ID',
-                  dataIndex: 'target',
-                  key: 'target',
-                  align: 'center',
-                  width: '35%',
-                  className: 'white',
-                  render: (val) => (
-                    <CopyTextButton
-                      displayText={`${val.slice(
-                        0,
-                        isMobile ? 2 : 6,
-                      )}...${val.slice(isMobile ? -2 : -6)}`}
-                      copyText={val}
-                      size={24}
-                      wrapperStyle={{
-                        position: 'unset',
-                        justifyContent: 'center',
-                      }}
-                    />
-                  ),
-                  onHeaderCell: () => {
-                    return {
-                      onClick: () => {
-                        rows.sort((a, b) =>
-                          sortAscending
-                            ? a.target.localeCompare(b.target)
-                            : b.target.localeCompare(a.target),
-                        );
-                        // forces update of rows
-                        setRows([...rows]);
-                        setSortOrder(!sortAscending);
-                      },
-                    };
-                  },
-                },
-                {
-                  title: 'Status',
-                  dataIndex: 'status',
-                  key: 'status',
-                  align: 'center',
-                  width: '10%',
-                  className: 'white',
-                  render: (val) => <TransactionStatus confirmations={val} />,
-                  onHeaderCell: () => {
-                    return {
-                      onClick: () => {
-                        rows.sort((a, b) =>
-                          sortAscending
-                            ? a.status - b.status
-                            : b.status - a.status,
-                        );
-                        // forces update of rows
-                        setRows([...rows]);
-                        setSortOrder(!sortAscending);
-                      },
-                    };
-                  },
-                },
-                {
-                  title: '',
-                  render: (val) => (
-                    <ManageAssetButtons
-                      asset={val.id}
-                      setShowModal={() => alert('hello!')}
-                      assetType={ASSET_TYPES.ANT}
-                    />
-                  ),
-                  align: 'right',
-                  width: '10%',
-                },
-              ]}
-              data={rows}
-              showHeader={true}
-              scroll={{ y: 300 }}
-            />
+            <AntTable antIds={walletANTs} refresh={() => setReload(!reload)} />
           )
         ) : (
           <></>

--- a/src/components/pages/Manage/Manage.tsx
+++ b/src/components/pages/Manage/Manage.tsx
@@ -1,12 +1,15 @@
+import Table from 'rc-table';
 import { useEffect, useState } from 'react';
 
-import { useWalletAddress } from '../../../hooks';
+import { useIsMobile, useWalletAddress } from '../../../hooks';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
-import { ArweaveTransactionID } from '../../../types';
+import { ASSET_TYPES, ArweaveTransactionID } from '../../../types';
 import { TABLE_TYPES } from '../../../types';
 import { CodeSandboxIcon } from '../../icons';
+import CopyTextButton from '../../inputs/buttons/CopyTextButton/CopyTextButton';
+import ManageAssetButtons from '../../inputs/buttons/ManageAssetButtons/ManageAssetButtons';
 import { Loader } from '../../layout';
-import { AntTable } from '../../layout/tables';
+import TransactionStatus from '../../layout/TransactionStatus/TransactionStatus';
 import './styles.css';
 
 function Manage() {
@@ -14,34 +17,64 @@ function Manage() {
   const { walletAddress } = useWalletAddress();
 
   const [tableType, setTableType] = useState(TABLE_TYPES.ANT); // ant_table or name_table
-
+  const [sortAscending, setSortOrder] = useState(true);
+  const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(false);
-  const [walletANTs, setWalletANTs] = useState<ArweaveTransactionID[]>([]);
   const [cursor] = useState<string | undefined>();
   const [reload, setReload] = useState(false);
+  const [rows, setRows] = useState<
+    {
+      name: string;
+      id: string;
+      target: string;
+      status: number;
+      key: number;
+    }[]
+  >([]);
 
   useEffect(() => {
-    // todo: move this to a seperate function to manage error state and poll for new ants to concat them to the state.
+    // todo: move this to a separate function to manage error state and poll for new ants to concat them to the state.
     // todo: load imported ants and names first
     if (walletAddress) {
       setIsLoading(true);
-      arweaveDataProvider
-        .getContractsForWallet(
-          arnsSourceContract.approvedANTSourceCodeTxs,
-          walletAddress,
-          cursor,
-        )
-        .then(({ ids }: { ids: ArweaveTransactionID[]; cursor?: string }) => {
-          setWalletANTs(ids);
-          // don't set cursor for now
-        })
-        .finally(() => setIsLoading(false))
-        .catch((error: Error) => {
-          console.error(error);
-          setIsLoading(false);
-        });
+      fetchAntRows(walletAddress).finally(() => setIsLoading(false));
     }
   }, [walletAddress, reload]);
+
+  async function fetchAntRows(address: ArweaveTransactionID) {
+    const { ids } = await arweaveDataProvider.getContractsForWallet(
+      arnsSourceContract.approvedANTSourceCodeTxs,
+      address,
+      cursor,
+    );
+    // TODO: make this row a type
+    const fetchedRows: {
+      name: string;
+      id: string;
+      target: string;
+      status: number;
+      key: number;
+    }[] = [];
+    for (const [index, id] of ids.entries()) {
+      const [contractState, confirmations] = await Promise.all([
+        arweaveDataProvider.getContractState(id),
+        arweaveDataProvider.getTransactionStatus(id),
+      ]);
+      const rowData = {
+        name: contractState.name ?? 'N/A',
+        id: id.toString(),
+        target:
+          contractState.records['@']?.transactionId ??
+          contractState.records['@'],
+        status: confirmations ?? 0,
+        key: index,
+      };
+      fetchedRows.push(rowData);
+    }
+    // sort by name by default
+    fetchedRows.sort((a, b) => a.name.localeCompare(b.name));
+    setRows(fetchedRows);
+  }
 
   return (
     <div className="page">
@@ -77,7 +110,146 @@ function Manage() {
               <Loader size={80} />
             </div>
           ) : (
-            <AntTable antIds={walletANTs} refresh={() => setReload(!reload)} />
+            <Table
+              rowClassName={'table-row'}
+              columns={[
+                {
+                  title: 'Nickname',
+                  dataIndex: 'name',
+                  key: 'name',
+                  align: 'left',
+                  width: '10%',
+                  className: 'white',
+                  ellipsis: true,
+                  onHeaderCell: () => {
+                    return {
+                      onClick: () => {
+                        rows.sort((a, b) =>
+                          // by default we sort by name
+                          !sortAscending
+                            ? a.name.localeCompare(b.name)
+                            : b.name.localeCompare(a.name),
+                        );
+                        // forces update of rows
+                        setRows([...rows]);
+                        setSortOrder(!sortAscending);
+                      },
+                    };
+                  },
+                },
+                {
+                  title: 'Contract ID',
+                  dataIndex: 'id',
+                  key: 'id',
+                  align: 'center',
+                  width: '35%',
+                  className: 'white',
+                  ellipsis: true,
+                  render: (val) => (
+                    <CopyTextButton
+                      displayText={`${val.slice(
+                        0,
+                        isMobile ? 2 : 6,
+                      )}...${val.slice(isMobile ? -2 : -6)}`}
+                      copyText={val}
+                      size={24}
+                      wrapperStyle={{
+                        position: 'unset',
+                        justifyContent: 'center',
+                      }}
+                    />
+                  ),
+                  onHeaderCell: () => {
+                    return {
+                      onClick: () => {
+                        rows.sort((a, b) =>
+                          sortAscending
+                            ? a.id.localeCompare(b.id)
+                            : b.id.localeCompare(a.id),
+                        );
+                        // forces update of rows
+                        setRows([...rows]);
+                        setSortOrder(!sortAscending);
+                      },
+                    };
+                  },
+                },
+                {
+                  title: 'Target ID',
+                  dataIndex: 'target',
+                  key: 'target',
+                  align: 'center',
+                  width: '35%',
+                  className: 'white',
+                  render: (val) => (
+                    <CopyTextButton
+                      displayText={`${val.slice(
+                        0,
+                        isMobile ? 2 : 6,
+                      )}...${val.slice(isMobile ? -2 : -6)}`}
+                      copyText={val}
+                      size={24}
+                      wrapperStyle={{
+                        position: 'unset',
+                        justifyContent: 'center',
+                      }}
+                    />
+                  ),
+                  onHeaderCell: () => {
+                    return {
+                      onClick: () => {
+                        rows.sort((a, b) =>
+                          sortAscending
+                            ? a.target.localeCompare(b.target)
+                            : b.target.localeCompare(a.target),
+                        );
+                        // forces update of rows
+                        setRows([...rows]);
+                        setSortOrder(!sortAscending);
+                      },
+                    };
+                  },
+                },
+                {
+                  title: 'Status',
+                  dataIndex: 'status',
+                  key: 'status',
+                  align: 'center',
+                  width: '10%',
+                  className: 'white',
+                  render: (val) => <TransactionStatus confirmations={val} />,
+                  onHeaderCell: () => {
+                    return {
+                      onClick: () => {
+                        rows.sort((a, b) =>
+                          sortAscending
+                            ? a.status - b.status
+                            : b.status - a.status,
+                        );
+                        // forces update of rows
+                        setRows([...rows]);
+                        setSortOrder(!sortAscending);
+                      },
+                    };
+                  },
+                },
+                {
+                  title: '',
+                  render: (val) => (
+                    <ManageAssetButtons
+                      asset={val.id}
+                      setShowModal={() => alert('hello!')}
+                      assetType={ASSET_TYPES.ANT}
+                    />
+                  ),
+                  align: 'right',
+                  width: '10%',
+                },
+              ]}
+              data={rows}
+              showHeader={true}
+              scroll={{ y: 300 }}
+            />
           )
         ) : (
           <></>

--- a/src/index.css
+++ b/src/index.css
@@ -462,7 +462,7 @@ button {
 }
 
 .rc-table-tbody > tr > td > input:focus {
-  outline: 2px solid #E0E0E0;
+  outline: 1px solid #e0e0e0;
   border-radius: 2px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -453,7 +453,7 @@ button {
 .rc-table-tbody > tr > td {
   border: 1px solid #323232;
   border-width: 1px 0px;
-  padding: 10px 15px;
+  padding: 10px 15px 10px 50px;
   font-size: 16px;
   height: 50px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -446,39 +446,29 @@ button {
   }
 }
 
-.table-header {
-  border-radius: var(--corner-radius);
-  height: 50px;
-  background-color: #323232;
-}
-
-.table-row {
-  height: 50px;
-  padding: 5px;
-  text-overflow: ellipsis;
-  border-spacing: 0 15px;
-  margin: 10px 0px;
-}
-
 .rc-table-content > table {
-  width: '100%' !important;
-  border-collapse: collapse;
+  border-spacing: 0px 10px;
 }
 
 .rc-table-header > table {
-  border-collapse: collapse;
-  width: 100%;
-  border-spacing: 20px 0;
-}
-
-.rc-table-body > table {
-  border-collapse: collapse;
   width: 100%;
 }
 
-.rc-table-thead {
-  border-radius: var(--corner-radius);
-  height: 50px;
-  background-color: #323232;
-  padding: 10px;
+.rc-table-tbody > tr > td {
+  border: 1px solid #323232;
+  border-width: 1px 0px;
+  padding: 10px 20px;
+  font-size: 16px;
+}
+
+.rc-table-tbody > tr > td:first-child {
+  border-left: 1px solid #323232;
+  border-top-left-radius: var(--corner-radius);
+  border-bottom-left-radius: var(--corner-radius);
+}
+
+.rc-table-tbody > tr > td:last-child {
+  border-right: 1px solid #323232;
+  border-top-right-radius: var(--corner-radius);
+  border-bottom-right-radius: var(--corner-radius);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -450,10 +450,6 @@ button {
   border-spacing: 0px 10px;
 }
 
-.rc-table-header > table {
-  width: 100%;
-}
-
 .rc-table-tbody > tr > td {
   border: 1px solid #323232;
   border-width: 1px 0px;

--- a/src/index.css
+++ b/src/index.css
@@ -450,12 +450,15 @@ button {
   border-spacing: 0px 10px;
 }
 
+.rc-table-tbody > tr {
+  height: 50px;
+}
+
 .rc-table-tbody > tr > td {
   border: 1px solid #323232;
   border-width: 1px 0px;
   padding: 10px 15px 10px 50px;
   font-size: 16px;
-  height: 50px;
 }
 
 .rc-table-tbody > .active-row {

--- a/src/index.css
+++ b/src/index.css
@@ -461,6 +461,11 @@ button {
   font-size: 16px;
 }
 
+.rc-table-tbody > tr > td > input:focus {
+  outline: 2px solid #E0E0E0;
+  border-radius: 2px;
+}
+
 .rc-table-tbody > .active-row {
   background-color: #757575;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -453,8 +453,13 @@ button {
 .rc-table-tbody > tr > td {
   border: 1px solid #323232;
   border-width: 1px 0px;
-  padding: 10px 20px;
+  padding: 10px 15px;
   font-size: 16px;
+  height: 50px;
+}
+
+.rc-table-tbody > .active-row {
+  background-color: #757575;
 }
 
 .rc-table-tbody > tr > td:first-child {

--- a/src/index.css
+++ b/src/index.css
@@ -445,3 +445,40 @@ button {
     height: 30px;
   }
 }
+
+.table-header {
+  border-radius: var(--corner-radius);
+  height: 50px;
+  background-color: #323232;
+}
+
+.table-row {
+  height: 50px;
+  padding: 5px;
+  text-overflow: ellipsis;
+  border-spacing: 0 15px;
+  margin: 10px 0px;
+}
+
+.rc-table-content > table {
+  width: '100%' !important;
+  border-collapse: collapse;
+}
+
+.rc-table-header > table {
+  border-collapse: collapse;
+  width: 100%;
+  border-spacing: 20px 0;
+}
+
+.rc-table-body > table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.rc-table-thead {
+  border-radius: var(--corner-radius);
+  height: 50px;
+  background-color: #323232;
+  padding: 10px;
+}


### PR DESCRIPTION
### Details
- migrates to `react-table-component` for ManageAntModal
- adds placeholders for editing/action's on ANT fields
- adds CSS to match figma

Screenshot:
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/12800001/215888796-5243dad6-9a92-4fdd-a4e9-ba3b9180433f.png">
Editing:
<img width="1643" alt="image" src="https://user-images.githubusercontent.com/12800001/215888852-48fa7bed-0ce4-48b9-bf18-eb9ef57ba364.png">

