### PR TITLE
feat(PE-3247): add cancel button to create ant input fields

### DIFF
--- a/src/components/modals/CreateAntModal/CreateAntModal.tsx
+++ b/src/components/modals/CreateAntModal/CreateAntModal.tsx
@@ -335,7 +335,7 @@ function CreateAntModal() {
                             position: 'relative',
                           }
                         : {
-                            width: '30%',
+                            width: '40%',
                             height: 'fit-content',
                             minWidth: '675px',
                             minHeight: '20%',
@@ -364,7 +364,7 @@ function CreateAntModal() {
                             dataIndex: 'attribute',
                             key: 'attribute',
                             align: 'left',
-                            width: isMobile ? '0px' : '10%',
+                            width: isMobile ? '0px' : '20%',
                             className: 'white small-row',
                             render: (value: string) => {
                               return `${mapKeyToAttribute(value)}:`;
@@ -376,6 +376,7 @@ function CreateAntModal() {
                             key: 'value',
                             align: 'left',
                             className: `white`,
+                            width: '40%',
                             render: (value: string | number, row: any) => {
                               if (row.editable)
                                 return (
@@ -392,11 +393,15 @@ function CreateAntModal() {
                                       }
                                       minNumber={100}
                                       maxNumber={1000000}
-                                      onClick={() =>
-                                        setEditingField(row.attribute)
-                                      }
+                                      onClick={() => {
+                                        setEditingField(row.attribute);
+                                      }}
                                       wrapperCustomStyle={{
-                                        minWidth: 'max-content',
+                                        width:
+                                          editingField != row.attribute
+                                            ? '175%'
+                                            : '100%',
+                                        minWidth: '200px',
                                       }}
                                       inputClassName={'flex'}
                                       inputCustomStyle={{
@@ -416,7 +421,7 @@ function CreateAntModal() {
                                             : 'white',
                                         padding:
                                           editingField === row.attribute
-                                            ? '10px '
+                                            ? '10px 40px 10px 10px'
                                             : '10px 0px',
                                         display: 'flex',
                                       }}
@@ -430,8 +435,9 @@ function CreateAntModal() {
                                           : row.value
                                       }
                                       setValue={(e) => {
-                                        setModifiedValue(e);
-                                        row.value = e;
+                                        if (row.attribute === editingField) {
+                                          setModifiedValue(e);
+                                        }
                                       }}
                                       validationPredicates={
                                         row.attribute === 'owner' ||
@@ -458,7 +464,7 @@ function CreateAntModal() {
                             dataIndex: 'action',
                             key: 'action',
                             align: 'right',
-                            width: 'fit-content',
+                            width: '40%',
                             className: 'white',
                             render: (value: any, row: any) => {
                               //TODO: if it's got an action attached, show it
@@ -468,6 +474,7 @@ function CreateAntModal() {
                                     {editingField !== row.attribute ? (
                                       <button
                                         onClick={() => {
+                                          setModifiedValue(undefined);
                                           setEditingField(row.attribute);
                                         }}
                                       >
@@ -504,6 +511,7 @@ function CreateAntModal() {
                                             borderColor: 'var(--accent)',
                                           }}
                                           onClick={() => {
+                                            row.value = modifiedValue;
                                             handleStateChange();
                                           }}
                                         >

--- a/src/components/modals/CreateAntModal/CreateAntModal.tsx
+++ b/src/components/modals/CreateAntModal/CreateAntModal.tsx
@@ -198,11 +198,9 @@ function CreateAntModal() {
         default:
           throw new Error('Editing field not supported');
       }
-
-      setEditingField(undefined);
-      setModifiedValue(undefined);
     } catch (error) {
       console.error(error);
+    } finally {
       setEditingField(undefined);
       setModifiedValue(undefined);
     }
@@ -226,8 +224,6 @@ function CreateAntModal() {
       }
       setAntContractId(new ArweaveTransactionID(pendingTXId));
       setIsPostingTransaction(false);
-      console.log(pendingTXId);
-
       return pendingTXId;
     } catch (error) {
       console.error(error);
@@ -263,8 +259,6 @@ function CreateAntModal() {
           onNext={() => {
             switch (workflowStage) {
               case 0:
-                // save any pending values
-                handleStateChange();
                 setWorkflowStage(workflowStage + 1);
                 if (!ant.records['@'].transactionId) {
                   ant.records = {
@@ -341,7 +335,7 @@ function CreateAntModal() {
                             position: 'relative',
                           }
                         : {
-                            width: '50%',
+                            width: '30%',
                             height: 'fit-content',
                             minWidth: '675px',
                             minHeight: '20%',
@@ -370,7 +364,7 @@ function CreateAntModal() {
                             dataIndex: 'attribute',
                             key: 'attribute',
                             align: 'left',
-                            width: isMobile ? '0px' : '20%',
+                            width: isMobile ? '0px' : '10%',
                             className: 'white small-row',
                             render: (value: string) => {
                               return `${mapKeyToAttribute(value)}:`;
@@ -381,7 +375,6 @@ function CreateAntModal() {
                             dataIndex: 'value',
                             key: 'value',
                             align: 'left',
-                            width: 'fit-content',
                             className: `white`,
                             render: (value: string | number, row: any) => {
                               if (row.editable)
@@ -399,11 +392,9 @@ function CreateAntModal() {
                                       }
                                       minNumber={100}
                                       maxNumber={1000000}
-                                      onClick={() => {
-                                        handleStateChange();
-                                        setEditingField(row.attribute);
-                                        setModifiedValue(row.value ?? '');
-                                      }}
+                                      onClick={() =>
+                                        setEditingField(row.attribute)
+                                      }
                                       wrapperCustomStyle={{
                                         minWidth: 'max-content',
                                       }}
@@ -433,7 +424,11 @@ function CreateAntModal() {
                                       placeholder={`Enter a ${mapKeyToAttribute(
                                         row.attribute,
                                       )}`}
-                                      value={row.value}
+                                      value={
+                                        editingField === row.attribute
+                                          ? modifiedValue
+                                          : row.value
+                                      }
                                       setValue={(e) => {
                                         setModifiedValue(e);
                                         row.value = e;
@@ -462,8 +457,8 @@ function CreateAntModal() {
                             title: '',
                             dataIndex: 'action',
                             key: 'action',
-                            width: '10%',
                             align: 'right',
+                            width: 'fit-content',
                             className: 'white',
                             render: (value: any, row: any) => {
                               //TODO: if it's got an action attached, show it
@@ -474,7 +469,6 @@ function CreateAntModal() {
                                       <button
                                         onClick={() => {
                                           setEditingField(row.attribute);
-                                          setModifiedValue(row.value);
                                         }}
                                       >
                                         <PencilIcon
@@ -486,18 +480,36 @@ function CreateAntModal() {
                                         />
                                       </button>
                                     ) : (
-                                      <button
-                                        className="assets-manage-button"
-                                        style={{
-                                          backgroundColor: 'var(--accent)',
-                                          borderColor: 'var(--accent)',
-                                        }}
-                                        onClick={() => {
-                                          handleStateChange();
-                                        }}
+                                      <div
+                                        className="flex flex-right"
+                                        style={{ gap: '0.5em', padding: '0px' }}
                                       >
-                                        Save
-                                      </button>
+                                        <button
+                                          className="flex center assets-manage-button"
+                                          style={{
+                                            backgroundColor: 'transparent',
+                                            color: 'white',
+                                          }}
+                                          onClick={() => {
+                                            setModifiedValue(undefined);
+                                            setEditingField(undefined);
+                                          }}
+                                        >
+                                          Cancel
+                                        </button>
+                                        <button
+                                          className="flex center assets-manage-button"
+                                          style={{
+                                            backgroundColor: 'var(--accent)',
+                                            borderColor: 'var(--accent)',
+                                          }}
+                                          onClick={() => {
+                                            handleStateChange();
+                                          }}
+                                        >
+                                          Save
+                                        </button>
+                                      </div>
                                     )}
                                   </>
                                 );

--- a/src/components/modals/CreateAntModal/CreateAntModal.tsx
+++ b/src/components/modals/CreateAntModal/CreateAntModal.tsx
@@ -400,7 +400,7 @@ function CreateAntModal() {
                                         width:
                                           editingField != row.attribute
                                             ? '175%'
-                                            : '100%',
+                                            : '125%',
                                         minWidth: '200px',
                                       }}
                                       inputClassName={'flex'}


### PR DESCRIPTION
## Details

Adds `Cancel` button to `Create Ant` modal - only saving values when `Save` is clicked.

<img width="977" alt="image" src="https://user-images.githubusercontent.com/12800001/229018757-ba6a38ae-4d58-4229-8f3e-03582a97c5d5.png">