### PR TITLE
feat(PE-3302): search domain name dynamic url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,8 +15,6 @@ import {
 import { About, Home, Manage, NotFound } from './components/pages';
 import { useArNSContract, useArweave } from './hooks/';
 import './index.css';
-import RegistrationStateProvider from './state/contexts/RegistrationState';
-import { registrationReducer } from './state/reducers/RegistrationReducer';
 
 function App() {
   // dispatches global state

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,14 +27,7 @@ function App() {
   const router = createHashRouter(
     createRoutesFromElements(
       <Route element={<Layout />} errorElement={<NotFound />}>
-        <Route
-          index
-          element={
-            <RegistrationStateProvider reducer={registrationReducer}>
-              <Home />
-            </RegistrationStateProvider>
-          }
-        />
+        <Route index element={<Home />} />
         <Route path="info" element={<About />} />
         <Route path="connect" element={<ConnectWalletModal />} />
         <Route

--- a/src/components/inputs/Search/SearchBar/SearchBar.tsx
+++ b/src/components/inputs/Search/SearchBar/SearchBar.tsx
@@ -51,7 +51,9 @@ function SearchBar(props: SearchBarProps) {
       setSearchBarText(value);
       _onFocus();
       _onSubmit();
+      return;
     }
+    setSearchBarText(undefined);
   }, [value]);
 
   function _onChange(e: React.ChangeEvent<HTMLInputElement>) {

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,8 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
 import { useGlobalState } from '../../../state/contexts/GlobalState';
-import RegistrationStateProvider from '../../../state/contexts/RegistrationState';
-import { registrationReducer } from '../../../state/reducers/RegistrationReducer';
 import Footer from '../Footer/Footer';
 import NavBar from '../Navbar/Navbar';
 import { Notifications } from '../Notifications/Notifications';
@@ -13,19 +11,17 @@ function Layout() {
 
   return (
     <>
-      <RegistrationStateProvider reducer={registrationReducer}>
-        <div className="header">
-          <NavBar />
-        </div>
-        <div className="body">
-          <Outlet />
-          {/* TODO: add errors here */}
-          <Notifications notifications={notifications} />
-        </div>
-        <div className="footer">
-          <Footer />
-        </div>
-      </RegistrationStateProvider>
+      <div className="header">
+        <NavBar />
+      </div>
+      <div className="body">
+        <Outlet />
+        {/* TODO: add errors here */}
+        <Notifications notifications={notifications} />
+      </div>
+      <div className="footer">
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,6 +1,8 @@
 import { Outlet } from 'react-router-dom';
 
 import { useGlobalState } from '../../../state/contexts/GlobalState';
+import RegistrationStateProvider from '../../../state/contexts/RegistrationState';
+import { registrationReducer } from '../../../state/reducers/RegistrationReducer';
 import Footer from '../Footer/Footer';
 import NavBar from '../Navbar/Navbar';
 import { Notifications } from '../Notifications/Notifications';
@@ -11,17 +13,19 @@ function Layout() {
 
   return (
     <>
-      <div className="header">
-        <NavBar />
-      </div>
-      <div className="body">
-        <Outlet />
-        {/* TODO: add errors here */}
-        <Notifications notifications={notifications} />
-      </div>
-      <div className="footer">
-        <Footer />
-      </div>
+      <RegistrationStateProvider reducer={registrationReducer}>
+        <div className="header">
+          <NavBar />
+        </div>
+        <div className="body">
+          <Outlet />
+          {/* TODO: add errors here */}
+          <Notifications notifications={notifications} />
+        </div>
+        <div className="footer">
+          <Footer />
+        </div>
+      </RegistrationStateProvider>
     </>
   );
 }

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import logo from '../../../../assets/images/logo/winston-white.gif';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
@@ -6,10 +6,8 @@ import NavGroup from './NavGroup/NavGroup';
 import './styles.css';
 
 function NavBar() {
-  // eslint-disable-next-line
-  const [{}, dispatchRegisterState] = useRegistrationState();
-  const [, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
+  const [, dispatchRegisterState] = useRegistrationState();
+
   return (
     <div className="flex-row flex-space-between">
       <div className="flex-row flex-left">
@@ -17,9 +15,7 @@ function NavBar() {
           className="hover"
           to="/"
           onClick={() => {
-            setSearchParams();
             dispatchRegisterState({ type: 'reset' });
-            navigate('/');
           }}
         >
           <img src={logo} className="brand-logo" alt="logo" />

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import logo from '../../../../assets/images/logo/winston-white.gif';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
@@ -8,18 +8,21 @@ import './styles.css';
 function NavBar() {
   // eslint-disable-next-line
   const [{}, dispatchRegisterState] = useRegistrationState();
+  const [, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   return (
     <div className="flex-row flex-space-between">
       <div className="flex-row flex-left">
-        <Link
+        <button
           className="hover"
-          to="/"
           onClick={() => {
+            setSearchParams();
             dispatchRegisterState({ type: 'reset' });
+            navigate('/');
           }}
         >
           <img src={logo} className="brand-logo" alt="logo" />
-        </Link>
+        </button>
       </div>
       <NavGroup />
     </div>

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import logo from '../../../../assets/images/logo/winston-white.gif';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import logo from '../../../../assets/images/logo/winston-white.gif';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
@@ -13,8 +13,9 @@ function NavBar() {
   return (
     <div className="flex-row flex-space-between">
       <div className="flex-row flex-left">
-        <button
+        <Link
           className="hover"
+          to="/"
           onClick={() => {
             setSearchParams();
             dispatchRegisterState({ type: 'reset' });
@@ -22,7 +23,7 @@ function NavBar() {
           }}
         >
           <img src={logo} className="brand-logo" alt="logo" />
-        </button>
+        </Link>
       </div>
       <NavGroup />
     </div>

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { useWalletAddress } from '../../../hooks/index';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
@@ -18,6 +19,7 @@ import Workflow from '../../layout/Workflow/Workflow';
 import './styles.css';
 
 function Home() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [{ arnsSourceContract }] = useGlobalState();
   const { walletAddress } = useWalletAddress();
   const [{ domain, antID, stage, isSearching }, dispatchRegisterState] =
@@ -26,6 +28,27 @@ function Home() {
   const [featuredDomains, setFeaturedDomains] = useState<{
     [x: string]: string;
   }>();
+
+  useEffect(() => {
+    if (domain) {
+      const serializeSearchParams: Record<string, string> = {
+        search: domain,
+      };
+      setSearchParams(serializeSearchParams);
+      return;
+    }
+  }, [domain]);
+
+  useEffect(() => {
+    const searchDomain = searchParams.get('search');
+    if (searchDomain && searchDomain !== domain) {
+      dispatchRegisterState({
+        type: 'setDomainName',
+        payload: searchDomain,
+      });
+      return;
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     if (Object.keys(arnsSourceContract.records).length) {
@@ -61,6 +84,7 @@ function Home() {
             }}
             onBack={() => {
               if (stage === 0) {
+                setSearchParams();
                 dispatchRegisterState({
                   type: 'reset',
                 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import GlobalStateProvider from './state/contexts/GlobalState';
-import { reducer } from './state/reducers/GlobalReducer';
+import RegistrationStateProvider from './state/contexts/RegistrationState.js';
+import { reducer, registrationReducer } from './state/reducers';
 import setupSentry from './utils/sentry';
 
 // Setup sentry monitoring
@@ -13,7 +14,9 @@ setupSentry();
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <GlobalStateProvider reducer={reducer}>
-      <App />
+      <RegistrationStateProvider reducer={registrationReducer}>
+        <App />
+      </RegistrationStateProvider>
     </GlobalStateProvider>
   </React.StrictMode>,
 );

--- a/src/state/reducers/index.ts
+++ b/src/state/reducers/index.ts
@@ -1,0 +1,2 @@
+export * from './GlobalReducer';
+export * from './RegistrationReducer';


### PR DESCRIPTION
## Details
Sets a `search` url param when searching for a name. This can later be extended to include details of registration like `Ant ID`, `Ticker`, `Years`, etc. that are all relevant for registering a name to create dynamic links for registering a name. In order to achieve proper `reset`, I moved `RegistrationProviderContext` to the top level, which would also allow us to register a name from anywhere in the app. 