### PR TITLE
fix(PE-3913): update useTransactionDataHook to set params based on Tr…

### DIFF
--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -1,15 +1,13 @@
 import { useEffect, useState } from 'react';
-import {
-  createSearchParams,
-  useNavigate,
-  useSearchParams,
-} from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useWalletAddress } from '../../../hooks/index';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
+import { useTransactionState } from '../../../state/contexts/TransactionState';
 import {
   ArweaveTransactionID,
+  BuyRecordPayload,
   CONTRACT_TYPES,
   REGISTRY_INTERACTION_TYPES,
 } from '../../../types';
@@ -31,6 +29,7 @@ import Workflow from '../../layout/Workflow/Workflow';
 import './styles.css';
 
 function Home() {
+  const [, dispatchTransactionState] = useTransactionState();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const [{ arnsSourceContract }] = useGlobalState();
@@ -91,13 +90,32 @@ function Home() {
             stage={stage.toString()}
             onNext={() => {
               if (stage == 1) {
-                const searchParameters = createSearchParams({
-                  data: [domain!, antID!.toString(), '1', '1'],
-                  contractType: CONTRACT_TYPES.REGISTRY,
-                  interactionType: REGISTRY_INTERACTION_TYPES.BUY_RECORD,
-                  assetId: ARNS_REGISTRY_ADDRESS,
+                const buyRecordPayload: BuyRecordPayload = {
+                  name: domain!,
+                  contractTxId: antID!.toString(),
+                  tierNumber: 1,
+                  years: 1,
+                };
+                dispatchTransactionState({
+                  type: 'setTransactionData',
+                  payload: {
+                    assetId: ARNS_REGISTRY_ADDRESS,
+                    functionName: 'buyRecord',
+                    ...buyRecordPayload,
+                  },
                 });
-                navigate(`/transaction?${searchParameters}`);
+                dispatchTransactionState({
+                  type: 'setContractType',
+                  payload: CONTRACT_TYPES.REGISTRY,
+                });
+                dispatchTransactionState({
+                  type: 'setInteractionType',
+                  payload: REGISTRY_INTERACTION_TYPES.BUY_RECORD,
+                });
+                // navigate to the transaction page, which will load the updated state of the transaction context
+                navigate('/transaction', {
+                  state: '/',
+                });
               }
               dispatchRegisterState({
                 type: 'setStage',

--- a/src/components/pages/Transaction/Transaction.tsx
+++ b/src/components/pages/Transaction/Transaction.tsx
@@ -1,60 +1,15 @@
-import { useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
 
 import { useTransactionData } from '../../../hooks';
-import { useTransactionState } from '../../../state/contexts/TransactionState';
-import {
-  AntInteraction,
-  ContractType,
-  RegistryInteraction,
-  TransactionData,
-} from '../../../types';
-import { Loader } from '../../layout';
 import TransactionWorkflow from '../../layout/TransactionWorkflow/TransactionWorkflow';
 
 function Transaction() {
-  const [
-    { contractType, interactionType, transactionData, workflowStage },
-    dispatchTransactionState,
-  ] = useTransactionState();
-  const { URLContractType, URLInteractionType, URLTransactionData } =
+  const { transactionData, contractType, interactionType, workflowStage } =
     useTransactionData();
+  const from = useLocation().state;
 
-  useEffect(() => {
-    if (URLTransactionData !== transactionData) {
-      dispatchTransactionState({
-        type: 'setTransactionData',
-        payload: URLTransactionData as TransactionData,
-      });
-    }
-    if (URLContractType !== contractType) {
-      dispatchTransactionState({
-        type: 'setContractType',
-        payload: URLContractType as ContractType,
-      });
-    }
-    if (URLInteractionType !== interactionType) {
-      dispatchTransactionState({
-        type: 'setInteractionType',
-        payload: URLInteractionType as AntInteraction | RegistryInteraction,
-      });
-    }
-  }, [URLContractType, URLInteractionType, URLTransactionData]);
-
-  if (
-    !transactionData ||
-    Object.keys(transactionData).includes('contractTxId')
-  ) {
-    return (
-      <div
-        className="page flex-column flex-center"
-        style={{ height: '100%', width: '100%', boxSizing: 'border-box' }}
-      >
-        <div className="flex flex-row text-large white bold center">
-          Loading Transaction Details
-        </div>
-        <Loader size={200} />
-      </div>
-    );
+  if (!transactionData) {
+    return <Navigate to={from ?? '/'} />;
   }
 
   return (

--- a/src/hooks/useTransactionData/useTransactionData.tsx
+++ b/src/hooks/useTransactionData/useTransactionData.tsx
@@ -1,55 +1,50 @@
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import {
+  createSearchParams,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom';
 
-import { AntInteraction, ContractType, RegistryInteraction } from '../../types';
-import { getTransactionPayloadByInteractionType } from '../../utils/searchUtils';
+import { useTransactionState } from '../../state/contexts/TransactionState';
 
 function useTransactionData() {
-  const [searchParams] = useSearchParams();
-  const [URLTransactionData, setURLTransactionData] = useState<{
-    [x: string]: any;
-  }>({});
-  const [URLAssetId, setURLAssetId] = useState<string>(
-    () => searchParams.get('assetId') ?? '',
-  );
-  const [URLContractType, setURLContractType] = useState<ContractType>(
-    () =>
-      (searchParams.get('contractType') as ContractType) ??
-      ('' as ContractType),
-  );
-  const [URLInteractionType, setURLInteractionType] = useState<
-    AntInteraction | RegistryInteraction
-  >(
-    (searchParams.get('interactionType') as
-      | AntInteraction
-      | RegistryInteraction) ?? ('' as AntInteraction | RegistryInteraction),
-  );
+  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
+  const from = useLocation().state;
+
+  const [{ transactionData, contractType, interactionType, workflowStage }] =
+    useTransactionState();
+
+  /**
+   * TODO: parse search params that are provided on initial page load and update the
+   * transaction state with those values. That will allow users to dynamically link
+   * transaction interactions.
+   */
 
   useEffect(() => {
-    const newURLAssetId = searchParams.get('assetId');
-    const newURLContractType = searchParams.get('contractType');
-    const newURLInteractionType = searchParams.get('interactionType');
-    const newURLTransactionData = searchParams.getAll('data');
-    setURLAssetId(newURLAssetId!);
-    setURLContractType(newURLContractType as ContractType);
-    setURLInteractionType(
-      newURLInteractionType as AntInteraction | RegistryInteraction,
-    );
-
-    if (newURLTransactionData) {
-      const payload = getTransactionPayloadByInteractionType(
-        URLContractType,
-        URLInteractionType,
-        newURLTransactionData,
-      );
-      if (payload) {
-        setURLTransactionData({ ...payload, assetId: URLAssetId });
-      }
+    if (!transactionData) {
+      navigate(from ?? '/');
+      return;
     }
-  }, [searchParams]);
-  // TODO: implement autofixes to type compatibility descrepencies ( if transaction data includes valid create ant keys for example, set the contract and interaction types appropriately)
 
-  return { URLTransactionData, URLContractType, URLInteractionType };
+    const updatedSearchParams = createSearchParams({
+      // TODO: sanitize these values
+      ...(transactionData as any),
+      contractType,
+      interactionType,
+      workflowStage,
+    });
+
+    setSearchParams(updatedSearchParams);
+  }, [transactionData, contractType, interactionType, workflowStage]);
+
+  return {
+    transactionData,
+    contractType,
+    interactionType,
+    workflowStage,
+  };
 }
 
 export default useTransactionData;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import GlobalStateProvider from './state/contexts/GlobalState';
-import RegistrationStateProvider from './state/contexts/RegistrationState.js';
+import RegistrationStateProvider from './state/contexts/RegistrationState';
 import TransactionStateProvider from './state/contexts/TransactionState';
 import { reducer, registrationReducer } from './state/reducers';
 import { transactionReducer } from './state/reducers/TransactionReducer';


### PR DESCRIPTION
…ansactionState

The way we had it, the TransactionState was updated based on URL params. This approach is very brittle, as a bad URL with the various type casting could easily break. Doing it this way, we can explicity set the TransactonState from anywhere in the app, and then update the URL accordingly. In a separate PR, we can add the logic that parses searchParams for transactionData values, and updates the TransactionState accordingly.