### PR TITLE
fix(sentry): sanitze sentry events relevant to PII

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -30,7 +30,29 @@ const sentry =
         ],
         tracesSampleRate: 1.0,
         environment: ENVIRONMENT,
+        beforeSend(event) {
+          return sanitizeEvent(event);
+        },
       })
     : {};
 
 export default sentry;
+
+const sanitizeEvent = (event: Sentry.Event): Sentry.Event => {
+  // Remove user's IP address
+  if (event.request) {
+    if (event.request.headers) {
+      delete event.request.headers['X-Forwarded-For'];
+    }
+    if (event.request.env) {
+      delete event.request.env['REMOTE_ADDR'];
+    }
+  }
+
+  // Remove user details
+  if (event.user) {
+    delete event.user; // Remove user object
+  }
+
+  return event;
+};


### PR DESCRIPTION
Inital PR to remove PII from sentry events.

We don't collect a lot of user information, so this is intended to remove any PII that we don't want to unintentionally share with sentry. 