### PR TITLE
PE-4935: Fix wallet connection issues

### DIFF
--- a/src/components/cards/NavMenuCard/NavMenuCard.tsx
+++ b/src/components/cards/NavMenuCard/NavMenuCard.tsx
@@ -90,7 +90,7 @@ function NavMenuCard() {
       // reset state
       setShowMenu(false);
       dispatchWalletState({
-        type: 'setWallet',
+        type: 'setWalletAddress',
         payload: undefined,
       });
     } catch (error: any) {

--- a/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
+++ b/src/components/inputs/buttons/ConnectButton/ConnectButton.tsx
@@ -1,17 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 
-import { useWalletState } from '../../../../state/contexts/WalletState';
 import './styles.css';
 
 function ConnectButton(): JSX.Element {
-  const [{ walletStateInitialized }] = useWalletState();
   const navigate = useNavigate();
   return (
     <button
       className="connect-button"
       style={{ textDecoration: 'none' }}
       onClick={() => navigate('connect')}
-      disabled={walletStateInitialized}
     >
       Connect
     </button>


### PR DESCRIPTION
* Enables connect button always and delegates responsibility for awaiting arweaveWallet injection back to ConnectWallet modal
* Fixes logout to only clear arweave wallet address rather than clearing the wallet connector (was causing problem to not get arconnect login second time and instead be redirected to arconnect.io)