### PR TITLE
PE-4988: fix-arconnect-event-listener-pattern

### DIFF
--- a/src/hooks/useArconnectEvents/useArconnectEvents.tsx
+++ b/src/hooks/useArconnectEvents/useArconnectEvents.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ArweaveTransactionID } from '../../services/arweave/ArweaveTransactionID';
 import { useGlobalState } from '../../state/contexts/GlobalState';
@@ -9,30 +9,49 @@ function useArconnectEvents() {
   const [{ wallet }, dispatchWalletState] = useWalletState();
   const [eventEmitter, setEventEmitter] = useState<any>();
 
-  window.addEventListener('arweaveWalletLoaded', () => {
-    const unknownApi = window.arweaveWallet as unknown as any; // TODO: when arconnect types are updated, remove this
-    if (unknownApi?.events) {
-      setEventEmitter(unknownApi.events);
-    }
-  });
+  useEffect(() => {
+    const arweaveWalletLoadedListener = () => {
+      const unknownApi = window.arweaveWallet as unknown as any; // TODO: when arconnect types are updated, remove this
+      if (unknownApi?.events) {
+        setEventEmitter(unknownApi.events);
+      }
+    };
 
-  if (eventEmitter) {
-    eventEmitter.on('gateway', (e: any) => {
+    window.addEventListener('arweaveWalletLoaded', arweaveWalletLoadedListener);
+
+    const gatewayListener = (e: any) => {
       dispatchGlobalState({
         type: 'setGateway',
         payload: e.host,
       });
-    });
+    };
 
-    eventEmitter.on('activeAddress', () => {
+    const addressListener = () => {
       wallet?.getWalletAddress().then((address: ArweaveTransactionID) => {
         dispatchWalletState({
           type: 'setWalletAddress',
           payload: address,
         });
       });
-    });
-  }
+    };
+
+    if (eventEmitter) {
+      eventEmitter.on('gateway', gatewayListener);
+      eventEmitter.on('activeAddress', addressListener);
+    }
+
+    return () => {
+      if (eventEmitter) {
+        eventEmitter.off('gateway', gatewayListener);
+        eventEmitter.off('activeAddress', addressListener);
+      }
+
+      window.removeEventListener(
+        'arweaveWalletLoaded',
+        arweaveWalletLoadedListener,
+      );
+    };
+  }, [dispatchGlobalState, dispatchWalletState, eventEmitter, wallet]);
 
   return eventEmitter;
 }


### PR DESCRIPTION
* Use useEffect with cleanup function to ensure only one listener at a time