### PR TITLE
fix(arconnect): throw an actual error when arconnect fails

### DIFF
--- a/src/services/wallets/ArConnectWalletConnector.ts
+++ b/src/services/wallets/ArConnectWalletConnector.ts
@@ -32,10 +32,7 @@ export class ArConnectWalletConnector implements ArweaveWalletConnector {
     const res = await executeWithTimeout(() => fn(), 3000);
 
     if (res === 'timeout') {
-      throw {
-        name: 'ArConnect',
-        message: ARCONNECT_UNRESPONSIVE_ERROR,
-      };
+      throw new Error(ARCONNECT_UNRESPONSIVE_ERROR);
     }
     return res as T;
   }


### PR DESCRIPTION
This is causing errors in sentry.