### PR TITLE
fix(PE-5432): add url param batching when search params overflow in url

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,6 +42,7 @@ export const APPROVED_CHARACTERS_REGEX = new RegExp(`^[a-zA-Z0-9-_]{0,61}$`);
 export const ALPHA_NUMERIC_REGEX = new RegExp('^[a-zA-Z0-9]$');
 export const ARNS_TX_ID_REGEX = new RegExp('^[a-zA-Z0-9-_s+]{43}$');
 export const ARNS_TX_ID_ENTRY_REGEX = new RegExp('^[a-zA-Z0-9-_s+]{1,43}$');
+export const ARWEAVE_TX_LENGTH = 43;
 export const EMAIL_REGEX = new RegExp(
   "([!#-'*+/-9=?A-Z^-~-]+(.[!#-'*+/-9=?A-Z^-~-]+)*|\"([]!#-[^-~ \t]|(\\[\t -~]))+\")@([!#-'*+/-9=?A-Z^-~-]+(.[!#-'*+/-9=?A-Z^-~-]+)*|[[\t -Z^-~]*])", // eslint-disable-line
 );

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,6 +5,13 @@ export class ContractInteractionError extends Error {
   }
 }
 
+export class ArNSServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArNS Service Error';
+  }
+}
+
 // NotificationOnlyError is an error that is only shown as a notification and does not emit to sentry
 
 export class NotificationOnlyError extends Error {


### PR DESCRIPTION
modifies the `getRecords` function to split url search params into batches and perform multiple queries, ensuring each query is under 2047 bytes.

If the query is too long then we get a 413 response, request too large.