### PR TITLE
chore: add throttle when loading process IDs to avoid rate limiting f…

### DIFF
--- a/src/hooks/useWalletANTs/useWalletANTs.tsx
+++ b/src/hooks/useWalletANTs/useWalletANTs.tsx
@@ -88,7 +88,7 @@ export function useWalletANTs() {
     try {
       setIsLoading(true);
       if (walletAddress) {
-        const newRows = await buildANTRows();
+        const newRows = buildANTRows();
         setRows(newRows);
       }
     } catch (error) {
@@ -424,7 +424,7 @@ export function useWalletANTs() {
     ];
   }
 
-  async function buildANTRows() {
+  function buildANTRows() {
     const fetchedRows: ANTMetadata[] = Object.entries(result.data.ants)
       .map(([processId, state], i) => {
         const { Name, Ticker, Owner, Controllers, Records } = state;

--- a/src/hooks/useWalletDomains/useWalletDomains.tsx
+++ b/src/hooks/useWalletDomains/useWalletDomains.tsx
@@ -94,7 +94,7 @@ export function useWalletDomains() {
     try {
       setIsLoading(true);
       if (walletAddress && result.data?.domains && result.data?.ants) {
-        const newRows = await buildDomainRows({
+        const newRows = buildDomainRows({
           domains: result.data?.domains,
           ants: result.data?.ants,
         });
@@ -393,7 +393,7 @@ export function useWalletDomains() {
     ];
   }
 
-  async function buildDomainRows({
+  function buildDomainRows({
     domains,
     ants,
   }: {


### PR DESCRIPTION
…rom ao

This will also help prevent memory overload issues in the browser for walletes with a lot of ants