### PR TITLE
PE-7155: metamask switching accounts does not update the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
+### Changed
+
+- Added support for account switching with Metamask
+
+### Fixed
+
+- Fixed auto-reconnect issue when disconnecting with Metamask and refreshing page
+
+## [1.0.0] - 2024-02-12
 
 ### Added
 

--- a/src/state/contexts/WalletState.tsx
+++ b/src/state/contexts/WalletState.tsx
@@ -172,7 +172,7 @@ export function WalletStateProvider({
           type: 'setWallet',
           payload: connector,
         });
-      } else if (ethAccount || walletType === WALLET_TYPES.ETHEREUM) {
+      } else if (walletType === WALLET_TYPES.ETHEREUM) {
         if (ethAccount?.isConnected && ethAccount?.address) {
           const connector = new EthWalletConnector(config);
 
@@ -194,6 +194,17 @@ export function WalletStateProvider({
       });
     }
   }
+
+  useEffect(() => {
+    if (
+      walletAddress &&
+      ethAccount.address !== walletAddress &&
+      ethAccount.isConnected &&
+      wallet instanceof EthWalletConnector
+    ) {
+      updateIfConnected();
+    }
+  }, [ethAccount, wallet, walletAddress]);
 
   return (
     <WalletStateContext.Provider value={[state, dispatchWalletState]}>


### PR DESCRIPTION
Also fixes issue when disconnecting with Metamask and refreshing page, app loaded as if connected to last wallet even though it was disconnected from Metamask.