### PR TITLE
fix(PE-8007): add handlers predicate to if we should update the domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.6.2] - 2025-04-28
+
+### Fixed
+
+- Upgrade Domain handles missing Reassign-Name handlers
+- ANT's with missing handlers will be flagged to update
+
 ## [1.6.1] - 2025-04-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/modals/ant-management/UpgradeDomainModal/UpgradeDomainModal.tsx
+++ b/src/components/modals/ant-management/UpgradeDomainModal/UpgradeDomainModal.tsx
@@ -99,6 +99,7 @@ function UpgradeDomainModal({
           state: previousState,
           name: lowerCaseDomain(domain),
           antModuleId,
+          luaCodeTxId: luaSourceId,
         },
         workflowName: ANT_INTERACTION_TYPES.UPGRADE_ANT,
         processId: domainData.processId,

--- a/src/components/modals/ant-management/UpgradeDomainsModal/UpgradeDomainsModal.tsx
+++ b/src/components/modals/ant-management/UpgradeDomainsModal/UpgradeDomainsModal.tsx
@@ -129,6 +129,7 @@ function UpgradeDomainsModal({
                   state: previousState,
                   name: lowerCaseDomain(domain),
                   antModuleId,
+                  luaCodeTxId: luaSourceId,
                 },
                 workflowName: ANT_INTERACTION_TYPES.UPGRADE_ANT,
                 processId: domainData.processId,

--- a/src/utils/searchUtils/searchUtils.ts
+++ b/src/utils/searchUtils/searchUtils.ts
@@ -1,3 +1,4 @@
+import { AntHandlerNames } from '@ar.io/sdk';
 import { ANTProcessData } from '@src/state';
 import emojiRegex from 'emoji-regex';
 import { asciiToUnicode, unicodeToAscii } from 'puny-coder';
@@ -150,7 +151,8 @@ export function getAntsRequiringUpdate({
       if (
         ant.processMeta.tags.find(
           (t) => t.name === 'Module' && t.value !== currentModuleId,
-        )
+        ) ||
+        !AntHandlerNames.every((h) => ant.handlers?.includes(h))
       )
         return id;
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced upgrade process to ensure ANTs support required handler before domain reassignment.
- **Bug Fixes**
	- Improved detection of ANTs that require updates by checking for missing handlers.
- **Chores**
	- Updated payloads to include additional transaction information during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->