### PR TITLE
fix(PE-8057): landing txid ttl rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 
 - Fix TTL rendering on domain management page
 
+### Changed
+
+- Updated default landing page transaction ID
+
 ## [1.7.1] - 2025-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.7.2] - 2025-05-05
+
+### Fixed
+
+- Fix TTL rendering on domain management page
+
 ## [1.7.1] - 2025-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/forms/DomainSettings/TTLRow.tsx
+++ b/src/components/forms/DomainSettings/TTLRow.tsx
@@ -70,7 +70,7 @@ export default function TTLRow({
               }
               disabled={!editing}
               placeholder={editing ? `Enter a new TTL` : ttlSeconds.toString()}
-              value={newTTL}
+              value={editing ? newTTL : ttlSeconds}
               setValue={(e) => setNewTTL(parseInt(e.toString()))}
               validationPredicates={{
                 [VALIDATION_INPUT_TYPES.VALID_TTL]: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -218,7 +218,7 @@ export const transactionByOwnerQuery = (address: ArweaveTransactionID) => {
 };
 
 export const LANDING_PAGE_TXID = new ArweaveTransactionID(
-  '-k7t8xMoB8hW482609Z9F4bTFMC3MnuW8bTvTyT8pFI',
+  'oork_YifB3-JQQZg8EgMPQJytua_QCHKNmMqt5kmnCo',
 );
 
 export const RESERVED_BREADCRUMB_TITLES = new Set([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected TTL value display on the domain management page to show the current value when not editing.
- **Chores**
	- Updated the default landing page transaction ID.
	- Incremented the app version to 1.7.2.
	- Added a changelog entry for version 1.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->