### PR TITLE
fix(PE-7975, PE-7976, PE-7979): add increase undernames to checkout page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.9.0] - 2025-05-09
+
+### Added
+
+- Increase Undername Support, Extend Lease, and Upgrade Domain workflows now
+  support card and credits payments.
+
 ## [1.8.0] - 2025-05-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.9.0",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^3.10.0-alpha.5",
+    "@ar.io/sdk": "^3.11.0-alpha.7",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@permaweb/aoconnect": "^0.0.59",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -324,7 +324,7 @@ function App() {
             }
           />
           <Route
-            path="register/:name/checkout"
+            path="/checkout"
             element={
               <Suspense
                 fallback={

--- a/src/components/inputs/Search/DomainPriceList.tsx
+++ b/src/components/inputs/Search/DomainPriceList.tsx
@@ -25,7 +25,7 @@ function DomainPiceList({ domain }: { domain: string }) {
       {priceList && priceList.lease > 0 ? (
         <span className="text-white align-center">
           Starting at ${(priceList.turboFiatLease / 100).toFixed(2)} USD, or{' '}
-          {formatARIO(new mARIOToken(priceList.buy).toARIO().valueOf())}{' '}
+          {formatARIO(new mARIOToken(priceList.lease).toARIO().valueOf())}{' '}
           {arioTicker}
         </span>
       ) : (

--- a/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
+++ b/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
@@ -173,7 +173,7 @@ function UpgradeUndernames() {
                     payload: ARNS_INTERACTION_TYPES.INCREASE_UNDERNAMES,
                   });
                   // navigate to the transaction page, which will load the updated state of the transaction context
-                  navigate('/transaction/review', {
+                  navigate(`/checkout`, {
                     state: `/manage/names/${lowerCaseDomain(
                       name,
                     )}/upgrade-undernames`,

--- a/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
+++ b/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
@@ -17,7 +17,6 @@ import {
   formatARIOWithCommas,
   lowerCaseDomain,
 } from '../../../utils';
-import { MAX_UNDERNAME_COUNT } from '../../../utils/constants';
 import Counter from '../../inputs/Counter/Counter';
 import WorkflowButtons from '../../inputs/buttons/WorkflowButtons/WorkflowButtons';
 import Loader from '../Loader/Loader';
@@ -109,7 +108,7 @@ function UpgradeUndernames() {
             </span>
           </div>
           <Counter
-            maxValue={MAX_UNDERNAME_COUNT - arnsRecord.undernameLimit}
+            maxValue={Number.MAX_SAFE_INTEGER - 1 - arnsRecord.undernameLimit}
             minValue={0}
             value={newUndernameCount}
             setValue={setNewUndernameCount}

--- a/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
+++ b/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
@@ -1,9 +1,8 @@
 import { mARIOToken } from '@ar.io/sdk/web';
-import WarningCard from '@src/components/cards/WarningCard/WarningCard';
-import { getTransactionDescription } from '@src/components/pages/Transaction/transaction-descriptions';
+import { useArNSIntentPrice } from '@src/hooks/useArNSIntentPrice';
+import { useCostDetails } from '@src/hooks/useCostDetails';
 import useDomainInfo from '@src/hooks/useDomainInfo';
-import { useIncreaseUndernameCost } from '@src/hooks/useIncreaseUndernameCost';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useIsMobile } from '../../../hooks';
@@ -13,13 +12,15 @@ import {
   ARNS_INTERACTION_TYPES,
   IncreaseUndernamesPayload,
 } from '../../../types';
-import { lowerCaseDomain } from '../../../utils';
+import {
+  formatARIO,
+  formatARIOWithCommas,
+  lowerCaseDomain,
+} from '../../../utils';
 import { MAX_UNDERNAME_COUNT } from '../../../utils/constants';
-import { InfoIcon } from '../../icons';
 import Counter from '../../inputs/Counter/Counter';
 import WorkflowButtons from '../../inputs/buttons/WorkflowButtons/WorkflowButtons';
 import Loader from '../Loader/Loader';
-import TransactionCost from '../TransactionCost/TransactionCost';
 
 function UpgradeUndernames() {
   const isMobile = useIsMobile();
@@ -31,10 +32,35 @@ function UpgradeUndernames() {
   const [newUndernameCount, setNewUndernameCount] = useState<number>(0);
   const { data: domainData } = useDomainInfo({ domain: name });
 
-  const { data: fee } = useIncreaseUndernameCost({
-    name: lowerCaseDomain(name ?? ''),
+  const { data: costDetails, isLoading: loadingCostDetails } = useCostDetails({
+    intent: 'Increase-Undername-Limit',
     quantity: newUndernameCount,
+    name: name as string,
   });
+  const { data: fiatFee, isLoading: loadingFiatFee } = useArNSIntentPrice({
+    intent: 'Increase-Undername-Limit',
+    name: name as string,
+    increaseQty: newUndernameCount,
+  });
+  const arioFee = costDetails?.tokenCost
+    ? new mARIOToken(costDetails.tokenCost).toARIO().valueOf()
+    : undefined;
+
+  const feeString = useMemo(() => {
+    if (newUndernameCount === 0) {
+      return `$0 USD ( 0 ${arioTicker} )`;
+    }
+    if (loadingCostDetails || loadingFiatFee) {
+      return `Calculating price...`;
+    }
+    if (arioFee && fiatFee) {
+      return `$${formatARIOWithCommas(
+        fiatFee.fiatEstimate.paymentAmount / 100,
+      )} USD ( ${formatARIO(arioFee)} ${arioTicker} )`;
+    }
+    return `Unable to calculate price`;
+  }, [arioFee, fiatFee, loadingCostDetails, loadingFiatFee, newUndernameCount]);
+
   const {
     arnsRecord,
     antProcess: antContract,
@@ -106,47 +132,15 @@ function UpgradeUndernames() {
             editable={true}
           />
         </div>
-        <TransactionCost
-          feeWrapperStyle={{
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: '100%',
-          }}
-          ioRequired={true}
-          fee={{
-            [arioTicker]:
-              newUndernameCount === 0
-                ? 0
-                : fee
-                ? new mARIOToken(fee).toARIO().valueOf()
-                : undefined,
-            ar: 0,
-          }}
-          info={
-            <div>
-              <WarningCard
-                wrapperStyle={{
-                  padding: '10px',
-                  fontSize: '14px',
-                  alignItems: 'center',
-                }}
-                customIcon={<InfoIcon width={'20px'} fill={'var(--accent)'} />}
-                text={
-                  getTransactionDescription({
-                    workflowName: ARNS_INTERACTION_TYPES.INCREASE_UNDERNAMES,
-                    arioTicker,
-                  }) || ''
-                }
-              />
-            </div>
-          }
-        />
+        <span className="flex text-white border-b border-dark-grey items-end pb-4 w-full justify-end">
+          {feeString}
+        </span>
         <WorkflowButtons
           backText="Cancel"
           nextText="Confirm"
           onBack={() => navigate(`/manage/names/${lowerCaseDomain(name)}`)}
           onNext={
-            !fee || fee < 0
+            !arioFee || arioFee < 0
               ? undefined
               : () => {
                   const increaseUndernamePayload: IncreaseUndernamesPayload = {
@@ -161,7 +155,7 @@ function UpgradeUndernames() {
                       assetId: arioProcessId,
                       functionName: 'increaseundernameLimit',
                       ...increaseUndernamePayload,
-                      interactionPrice: new mARIOToken(fee).toARIO().valueOf(),
+                      interactionPrice: arioFee,
                     },
                   });
                   dispatchTransactionState({

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -225,6 +225,21 @@ function Checkout() {
             </div>
           ),
         };
+      case ARNS_INTERACTION_TYPES.EXTEND_LEASE:
+        return {
+          'Lease Duration': (
+            <span className="text-white">
+              {transaction?.years}{' '}
+              {transaction?.years && transaction?.years > 1 ? 'years' : 'year'}
+            </span>
+          ),
+        };
+      case ARNS_INTERACTION_TYPES.UPGRADE_NAME:
+        return {
+          'Lease Duration': (
+            <span className="text-success font-sans-bold">Permanent</span>
+          ),
+        };
       default:
         return {};
     }

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -196,6 +196,40 @@ function Checkout() {
     };
   }, [costDetail, paymentMethod, intentPrice, promoCode]);
 
+  const orderSummary = useMemo(() => {
+    switch (workflowName) {
+      case ARNS_INTERACTION_TYPES.BUY_RECORD:
+        return {
+          'Lease Duration':
+            transaction?.type === TRANSACTION_TYPES.BUY
+              ? 'Permabuy (never expires)'
+              : `${transaction?.years} ${
+                  transaction?.years && transaction?.years > 1
+                    ? 'years'
+                    : 'year'
+                }`,
+          Undernames: '10 included',
+        };
+      case ARNS_INTERACTION_TYPES.INCREASE_UNDERNAMES:
+        return {
+          Undernames: (
+            <div className="flex items-center gap-2">
+              {' '}
+              <span className="text-white bg-white/10 p-1 px-3 rounded font-bold">
+                {(transactionData as any)?.oldQty}
+              </span>{' '}
+              +{' '}
+              <span className="text-success bg-success-thin p-1 px-3 rounded font-bold">
+                {transaction?.qty}
+              </span>
+            </div>
+          ),
+        };
+      default:
+        return {};
+    }
+  }, [workflowName, transaction]);
+
   const quoteEndTimestamp = useMemo(() => {
     if (paymentMethod === 'card') {
       return intentPriceUpdatedAt + COST_DETAIL_STALE_TIME;
@@ -296,22 +330,30 @@ function Checkout() {
         style={isMobile ? {} : { gap: '0px', maxWidth: '900px', width: '100%' }}
       >
         <div className="flex flex-row border-b border-dark-grey pb-6 w-full mb-10">
-          <StepProgressBar
-            stage={3}
-            stages={[
-              { title: 'Choose', description: 'Pick a name', status: 'finish' },
-              {
-                title: 'Configure',
-                description: 'Choose purchase duration',
-                status: 'finish',
-              },
-              {
-                title: 'Checkout',
-                description: 'Complete payment',
-                status: 'process',
-              },
-            ]}
-          />
+          {workflowName === ARNS_INTERACTION_TYPES.BUY_RECORD ? (
+            <StepProgressBar
+              stage={3}
+              stages={[
+                {
+                  title: 'Choose',
+                  description: 'Pick a name',
+                  status: 'finish',
+                },
+                {
+                  title: 'Configure',
+                  description: 'Choose purchase duration',
+                  status: 'finish',
+                },
+                {
+                  title: 'Checkout',
+                  description: 'Complete payment',
+                  status: 'process',
+                },
+              ]}
+            />
+          ) : (
+            <span className="text-white text-bold text-2xl">Review</span>
+          )}
         </div>
 
         <div className="flex md:flex-row flex-col gap-6 w-full h-full">
@@ -320,17 +362,7 @@ function Checkout() {
               domain={transaction?.name}
               antId={transaction?.processId}
               targetId={transaction?.targetId?.toString()}
-              orderSummary={{
-                'Lease Duration':
-                  transaction?.type === TRANSACTION_TYPES.BUY
-                    ? 'Permabuy (never expires)'
-                    : `${transaction?.years} ${
-                        transaction?.years && transaction?.years > 1
-                          ? 'years'
-                          : 'year'
-                      }`,
-                Undernames: '10 included',
-              }}
+              orderSummary={orderSummary}
               fees={fees}
               quoteEndTimestamp={quoteEndTimestamp}
               refresh={handleRefresh}

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -211,7 +211,7 @@ function RegisterNameForm() {
       payload: ARNS_INTERACTION_TYPES.BUY_RECORD,
     });
     // navigate to the transaction page, which will load the updated state of the transaction context
-    navigate(`/register/${domain}/checkout`, {
+    navigate(`/checkout`, {
       state: `/register/${domain}`,
     });
   }

--- a/src/services/turbo/TurboArNSClient.ts
+++ b/src/services/turbo/TurboArNSClient.ts
@@ -308,6 +308,7 @@ export class TurboArNSClient {
     processId?: string;
     paymentMethodId: string;
     email?: string;
+    address: string;
   }): Promise<AoMessageResult<MessageResult>> {
     const intent = await this.getArNSPaymentIntent(intentParams);
     if (!intent.paymentSession.client_secret) {

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -255,6 +255,7 @@ export default async function dispatchArIOInteraction({
             throw new Error('Turbo ArNS Client is not defined');
           }
           result = await turboArNSClient.executeArNSIntent({
+            address: owner.toString(),
             name: lowerCaseDomain(payload.name),
             intent: 'Upgrade-Name',
             paymentMethodId: payload.paymentMethodId,

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -177,6 +177,7 @@ export default async function dispatchArIOInteraction({
             throw new Error('Turbo ArNS Client is not defined');
           }
           result = await turboArNSClient.executeArNSIntent({
+            address: owner.toString(),
             name: lowerCaseDomain(payload.name),
             increaseQty: payload.qty,
             intent: 'Increase-Undername-Limit',

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -283,6 +283,7 @@ export default async function dispatchArIOInteraction({
     clearTimeout(aoCongestedTimeout);
     queryClient.invalidateQueries({
       predicate: ({ queryKey }) =>
+        queryKey.includes('io-balance') ||
         queryKey.includes('ario-liquid-balance') ||
         queryKey.includes('ario-delegated-stake') ||
         queryKey.includes('turbo-credit-balance') ||

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -282,7 +282,11 @@ export default async function dispatchArIOInteraction({
     });
     clearTimeout(aoCongestedTimeout);
     queryClient.invalidateQueries({
-      queryKey: ['turbo-credit-balance'],
+      predicate: ({ queryKey }) =>
+        queryKey.includes('ario-liquid-balance') ||
+        queryKey.includes('ario-delegated-stake') ||
+        queryKey.includes('turbo-credit-balance') ||
+        queryKey.includes(lowerCaseDomain(payload.name)),
     });
   }
   if (!result) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,10 +93,10 @@
     resize-observer-polyfill "^1.5.1"
     throttle-debounce "^5.0.0"
 
-"@ar.io/sdk@^3.10.0-alpha.5":
-  version "3.10.0-alpha.5"
-  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.10.0-alpha.5.tgz#c53c11eff353c1d29917271051cf7057611b25f5"
-  integrity sha512-O2xU+UfD8hPu8l7np9TUHBHBFiLAWCTzKcwCCO/vSZ0NAUojx/Kl5Pn7FDv35d+bv5qFrVamwn6fP2Ue8KKLFg==
+"@ar.io/sdk@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.10.1.tgz#f5c377e6dca428d6e6127842289817b3dd4b116f"
+  integrity sha512-Jl8Md2u0tUBR5WChR8Qt6i4Uq6TleCZJRXTR8UheJdg+H6tulYkZ6WzbHmtH+EufnBfdOW7nf1DZPBe5jAtDsQ==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
@@ -107,14 +107,13 @@
     eventemitter3 "^5.0.1"
     plimit-lit "^3.0.1"
     prompts "^2.4.2"
-    uuid "^11.1.0"
     winston "^3.13.0"
     zod "^3.23.8"
 
-"@ar.io/sdk@^3.10.1":
-  version "3.10.1"
-  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.10.1.tgz#f5c377e6dca428d6e6127842289817b3dd4b116f"
-  integrity sha512-Jl8Md2u0tUBR5WChR8Qt6i4Uq6TleCZJRXTR8UheJdg+H6tulYkZ6WzbHmtH+EufnBfdOW7nf1DZPBe5jAtDsQ==
+"@ar.io/sdk@^3.11.0-alpha.7":
+  version "3.11.0-alpha.7"
+  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.11.0-alpha.7.tgz#6d87b764691b072fe5e88238a7ff053c41ad4f90"
+  integrity sha512-6K6G7Pg8xczYjpljfPmx7iKpMy+cUQ/2gc0xTWw/Zbofqo5dz5sZxyriSWFDYJN/BchQBpG76UnVrQgrvcp11A==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
@@ -15598,11 +15597,6 @@ utility-types@^3.10.0:
   version "3.11.0"
   resolved "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz#607c40edb4f258915e901ea7995607fdf319424c"
   integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
-
-uuid@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Checkout page now displays a dynamic order summary tailored to the specific workflow, providing clearer details for different transaction types.

- **Refactor**
  - The URL for accessing the Checkout page has been simplified to "/checkout", making navigation more straightforward.
  - Navigation after certain actions has been updated to use the new Checkout route, improving consistency across the app.
  - Fee displays in upgrade and lease components now include both token and fiat price estimates, with simplified UI and validation.
  - Undername upgrade limits have been expanded significantly, removing previous fixed limits.
  - Payment handling now supports both token and fiat funding sources, enabling more flexible transaction processing.
  - The step progress bar on the Checkout page is conditionally displayed based on the workflow, enhancing user clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->