### PR TITLE
fix(PE-8158): parse punycode domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.10.1] - 2025-06-10
+
+### Fixed
+
+- Fixed rendering of domain to show non-punycode domain.
+
 ## [1.10.0] - 2025-05-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/cards/DomainCheckoutCard.tsx
+++ b/src/components/cards/DomainCheckoutCard.tsx
@@ -1,7 +1,7 @@
 import { useCountdown } from '@src/hooks/useCountdown';
 import useDomainInfo from '@src/hooks/useDomainInfo';
 import { useWalletState } from '@src/state';
-import { isArweaveTransactionID } from '@src/utils';
+import { decodeDomainToASCII, isArweaveTransactionID } from '@src/utils';
 import { DEFAULT_ANT_LOGO } from '@src/utils/constants';
 import { RotateCw } from 'lucide-react';
 import { ReactNode } from 'react';
@@ -63,11 +63,11 @@ function DomainCheckoutCard({
                   border: '1px solid var(--text-faded)',
                 },
               }}
-              message={domain}
+              message={decodeDomainToASCII(domain)}
               icon={
                 <span className="text-white max-w-[11.25rem] truncate">
                   {' '}
-                  {domain}
+                  {decodeDomainToASCII(domain)}
                 </span>
               }
             />

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -23,6 +23,7 @@ import {
   VALIDATION_INPUT_TYPES,
 } from '../../../types';
 import {
+  decodeDomainToASCII,
   encodeDomainToASCII,
   formatARIO,
   formatARIOWithCommas,
@@ -267,7 +268,8 @@ function RegisterNameForm() {
           style={{ fontWeight: '500px', fontSize: '23px', gap: '15px' }}
         >
           <span style={{ color: 'var(--success-green)' }}>
-            {domain} <span className={'white'}>is available!</span>
+            {decodeDomainToASCII(domain)}{' '}
+            <span className={'white'}>is available!</span>
           </span>{' '}
           <CheckCircleFilled
             style={{ fontSize: '20px', color: 'var(--success-green)' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected domain display to show domains in their non-punycode (ASCII-decoded) form throughout the interface, including tooltips and availability messages.

- **Chores**
  - Updated documentation to reflect the new patch version 1.10.1 and noted the domain rendering fix in the changelog.
  - Incremented app version to 1.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->