### PR TITLE
chore(ario): bumps ar-io-sdk to leverage hyperbeam node for ANT reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^3.14.0-alpha.2",
+    "@ar.io/sdk": "^3.14.0-alpha.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@permaweb/aoconnect": "^0.0.59",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,10 +110,10 @@
     winston "^3.13.0"
     zod "^3.23.8"
 
-"@ar.io/sdk@^3.14.0-alpha.2":
-  version "3.14.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.14.0-alpha.2.tgz#4b50a6411ef2e1a8faace9cd53f30b0de1d70715"
-  integrity sha512-h6HzkDxkZXFQuWIPifKv2GgJuAJoJkGCY+F+aH9Yh4X9erOkBsGGl/UykuySm+crr0N37rd8Kex2KyPU4yA91w==
+"@ar.io/sdk@^3.14.0-alpha.4":
+  version "3.14.0-alpha.4"
+  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.14.0-alpha.4.tgz#b2b1e165f288765e489d96b13acd035a98173c25"
+  integrity sha512-+9mTRMRRP1OlcK8eEhKLADiIBskSAuuR5eo3ThIU+gv36fFebPBKc69pvDtGW6Sx8IGNnBFw36OiivC0SkN7MA==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "0.0.68"


### PR DESCRIPTION
We will update the default hyperbeam url to a production one as we test hyperbeam reads in arns.app. We should also look to remove the depedency on Handlers for upgrade paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the "@ar.io/sdk" dependency to allow installation of newer compatible versions, including alpha releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->