### PR TITLE
Fix typos in comments

### DIFF
--- a/src/components/modals/turbo/TurboTopUpModal.tsx
+++ b/src/components/modals/turbo/TurboTopUpModal.tsx
@@ -243,7 +243,7 @@ function TurboTopUpModal({ onClose }: { onClose: () => void }) {
   const stripePromise = useMemo(() => {
     return loadStripe(turboNetwork.STRIPE_PUBLISHABLE_KEY);
   }, [turboNetwork.STRIPE_PUBLISHABLE_KEY]);
-  // we wrap the modal in an Elements component to ensure that the CardElement is mounted seperately from the global elements context
+  // we wrap the modal in an Elements component to ensure that the CardElement is mounted separately from the global elements context
   // if two card elements are mounted at the same time, the second one will CRASH the app
   return (
     <Elements stripe={stripePromise}>

--- a/src/hooks/useIsFocused/useIsFocused.tsx
+++ b/src/hooks/useIsFocused/useIsFocused.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export function useIsFocused(id: string) {
-  // helpful when you need to modify the style of a seperate element when another element is focused
+  // helpful when you need to modify the style of a separate element when another element is focused
   const [isFocused, setIsFocused] = useState<boolean>(false);
 
   useEffect(() => {

--- a/src/utils/searchUtils/searchUtils.ts
+++ b/src/utils/searchUtils/searchUtils.ts
@@ -209,7 +209,7 @@ export function isMaxLeaseDuration(duration: number | string) {
 }
 
 /**
- * @description - Formats the ArNS domain as ascii with the appropriate underscore seperator
+ * @description - Formats the ArNS domain as ascii with the appropriate underscore separator
  * @param name - unicode representation of the arns name
  * @returns ascii representation of the domain
  */
@@ -234,7 +234,7 @@ export function encodePrimaryName(name: string) {
 }
 
 /**
- * @description - Formats the ArNS domain as unicode with the appropriate underscore seperator
+ * @description - Formats the ArNS domain as unicode with the appropriate underscore separator
  * @param name - ascii representation of the arns name
  * @returns unicode representation of the domain
  */


### PR DESCRIPTION
## Summary
- fix comment spelling for mounting explanation
- tweak wording in focus hook comment
- fix spelling in domain formatting docs

## Testing
- `yarn test` *(fails: import.meta not allowed)*

------
https://chatgpt.com/codex/tasks/task_b_684c9ca355f0832ea67c3b5d6c954932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected spelling mistakes in comments and documentation across multiple components. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->