### PR TITLE
Fix useIsMobile effect dependencies

### DIFF
--- a/src/hooks/useIsMobile/useIsMobile.tsx
+++ b/src/hooks/useIsMobile/useIsMobile.tsx
@@ -11,7 +11,9 @@ export function useIsMobile(): boolean {
     return () => {
       window.removeEventListener('resize', updateIsMobile);
     };
-  }, [isMobile]);
+    // The dependency array is intentionally empty so the listener is only
+    // attached once on mount and cleaned up on unmount.
+  }, []);
 
   function updateIsMobile(): void {
     setIsMobile(window.innerWidth < 600);


### PR DESCRIPTION
## Summary
- register resize listener only once in `useIsMobile`

## Testing
- `yarn lint:check`
- `yarn test` *(fails: 'import.meta' meta-property only allowed when module option is 'es2020', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c9cae46a4832eaab4ef64aa62067b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance and reliability of mobile detection by ensuring resize event listeners are managed correctly.

- **Documentation**
  - Added a clarifying comment regarding the event listener setup for better code understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->