### PR TITLE
fix(PE-8349): use hb url in ant registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "3.14.0",
+    "@ar.io/sdk": "3.14.1-alpha.2",
     "@ar.io/wayfinder-core": "^1.0.4",
     "@ar.io/wayfinder-react": "^1.0.6",
     "@ardrive/turbo-sdk": "^1.23.1",

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -50,7 +50,6 @@ export default async function dispatchArIOInteraction({
   signer?: ContractSigner;
   ao?: AoClient;
   antAo?: AoClient;
-
   hyperbeamUrl?: string;
   scheduler?: string;
   fundFrom?: FundFrom | 'fiat';
@@ -98,6 +97,7 @@ export default async function dispatchArIOInteraction({
           });
           const antRegistry = ANTRegistry.init({
             signer,
+            hyperbeamUrl,
             process: new AOProcess({
               processId: ANT_REGISTRY_ID,
               ao,

--- a/src/state/actions/dispatchArNSUpdate.ts
+++ b/src/state/actions/dispatchArNSUpdate.ts
@@ -56,6 +56,7 @@ export async function dispatchArNSUpdate({
       process: new AOProcess({ processId: arioProcessId, ao }),
     }) as AoARIORead;
     const antRegistry = ANTRegistry.init({
+      hyperbeamUrl,
       process: new AOProcess({
         processId: ANT_REGISTRY_ID,
         ao: connect(aoNetworkSettings.ANT),

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,7 +93,25 @@
     resize-observer-polyfill "^1.5.1"
     throttle-debounce "^5.0.0"
 
-"@ar.io/sdk@3.14.0", "@ar.io/sdk@^3.10.1":
+"@ar.io/sdk@3.14.1-alpha.2":
+  version "3.14.1-alpha.2"
+  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.14.1-alpha.2.tgz#0345c8d1866a4518e23bbf99725ed2439dba6532"
+  integrity sha512-Y3vgUKIyV+xcvReGFEhBwigazwZjYs9LiVOL5A4Mp38igmNhXi0AS1en3Y5tMmSPBWORthKwrFHRtkO9MGczPw==
+  dependencies:
+    "@dha-team/arbundles" "^1.0.1"
+    "@permaweb/aoconnect" "0.0.68"
+    arweave "1.15.5"
+    axios "1.8.4"
+    axios-retry "^4.3.0"
+    commander "^12.1.0"
+    eventemitter3 "^5.0.1"
+    plimit-lit "^3.0.1"
+    prompts "^2.4.2"
+    uuid "^11.1.0"
+    winston "^3.13.0"
+    zod "^3.23.8"
+
+"@ar.io/sdk@^3.10.1":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.14.0.tgz#aadfd03ca157d017265df39b12c8f57633303ee5"
   integrity sha512-1moIb3CZzS7qu16K7CM8nc4vzuG4AHzXLVo711P+s5mSioZ235wshiXDJscQ2kZku4m/XpLSo1eEYv300AgAEA==


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced configuration options by supporting the `hyperbeamUrl` parameter in certain workflows.

* **Chores**
  * Updated the dependency "@ar.io/sdk" to version 3.14.1-alpha.2.

* **Style**
  * Removed an unnecessary blank line for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->