### PR TITLE
feat(manage): add undername inline on manage page

### DIFF
--- a/src/components/data-display/tables/UndernamesSubtable.tsx
+++ b/src/components/data-display/tables/UndernamesSubtable.tsx
@@ -3,7 +3,7 @@ import { ExternalLinkIcon, PencilIcon } from '@src/components/icons';
 import ArweaveID, {
   ArweaveIdTypes,
 } from '@src/components/layout/ArweaveID/ArweaveID';
-import { EditUndernameModal } from '@src/components/modals';
+import { AddUndernameModal, EditUndernameModal } from '@src/components/modals';
 import ConfirmTransactionModal from '@src/components/modals/ConfirmTransactionModal/ConfirmTransactionModal';
 import { usePrimaryName } from '@src/hooks/usePrimaryName';
 import { ArweaveTransactionID } from '@src/services/arweave/ArweaveTransactionID';
@@ -15,7 +15,13 @@ import {
   useWalletState,
 } from '@src/state';
 import dispatchANTInteraction from '@src/state/actions/dispatchANTInteraction';
-import { ANT_INTERACTION_TYPES, TransactionDataPayload } from '@src/types';
+import {
+  ANT_INTERACTION_TYPES,
+  SetRecordPayload,
+  TransactionDataPayload,
+  UNDERNAME_TABLE_ACTIONS,
+  UndernameTableInteractionTypes,
+} from '@src/types';
 import {
   camelToReadable,
   decodeDomainToASCII,
@@ -26,7 +32,7 @@ import {
 import { MIN_ANT_VERSION, NETWORK_DEFAULTS } from '@src/utils/constants';
 import eventEmitter from '@src/utils/events';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { Star } from 'lucide-react';
+import { Plus, Star } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { ReactNode } from 'react-markdown';
 import { Link } from 'react-router-dom';
@@ -57,22 +63,84 @@ const UndernamesSubtable = ({
   state?: AoANTState | null;
 }) => {
   const [{ arioProcessId, antAoClient, hyperbeamUrl }] = useGlobalState();
+  const [, dispatchArNSState] = useArNSState();
+
   const [{ wallet, walletAddress }] = useWalletState();
   const isOwner = walletAddress
     ? state?.Owner === walletAddress.toString()
     : false;
   const [, dispatchTransactionState] = useTransactionState();
-  const [, dispatchArNSState] = useArNSState();
   const [, dispatchModalState] = useModalState();
   const { data: primaryNameData } = usePrimaryName();
   const [tableData, setTableData] = useState<Array<TableData>>([]);
-  // modal state
+
+  const [action, setAction] = useState<
+    UndernameTableInteractionTypes | undefined
+  >();
   const [transactionData, setTransactionData] = useState<
     TransactionDataPayload | undefined
   >();
-  const [showEditUndernameModal, setShowEditUndernameModal] =
-    useState<boolean>(false);
+  const [interactionType, setInteractionType] =
+    useState<ANT_INTERACTION_TYPES>();
   const [selectedUndername, setSelectedUndername] = useState<string>();
+
+  async function handleInteraction({
+    payload,
+    workflowName,
+    processId,
+  }: {
+    payload: TransactionDataPayload;
+    workflowName: ANT_INTERACTION_TYPES;
+    processId?: string;
+  }) {
+    try {
+      if (!processId) {
+        throw new Error('Unable to interact with ANT contract - missing ID.');
+      }
+
+      if (!wallet?.contractSigner || !walletAddress) {
+        throw new Error(
+          'Unable to interact with ANT contract - missing signer.',
+        );
+      }
+
+      const { id } = await dispatchANTInteraction({
+        processId,
+        payload,
+        workflowName,
+        signer: wallet?.contractSigner,
+        owner: walletAddress?.toString(),
+        dispatchTransactionState,
+        dispatchArNSState,
+        ao: antAoClient,
+        hyperbeamUrl,
+      });
+      eventEmitter.emit('success', {
+        name: 'Manage Undernames',
+        message: (
+          <span
+            className="flex flex-row whitespace-nowrap"
+            style={{ gap: '10px' }}
+          >
+            {workflowName} complete.{' '}
+            <ArweaveID
+              id={new ArweaveTransactionID(id)}
+              type={ArweaveIdTypes.INTERACTION}
+              shouldLink
+              characterCount={8}
+            />
+          </span>
+        ),
+      });
+      // refresh the row
+      setTableData(tableData);
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    } finally {
+      setTransactionData(undefined);
+      setInteractionType(undefined);
+    }
+  }
 
   useEffect(() => {
     if (undernames) {
@@ -155,7 +223,7 @@ const UndernamesSubtable = ({
                   className="fill-grey hover:fill-white"
                   onClick={() => {
                     setSelectedUndername(undername);
-                    setShowEditUndernameModal(true);
+                    setAction(UNDERNAME_TABLE_ACTIONS.EDIT);
                   }}
                 >
                   <PencilIcon width={'18px'} height={'18px'} fill="inherit" />
@@ -273,48 +341,70 @@ const UndernamesSubtable = ({
 
           return '';
         }}
+        addOnAfterTable={
+          isOwner ? (
+            <div className="w-full flex flex-row text-primary font-semibold rounded-b-md border-b-[1px] border-x-[1px] border-dark-grey text-sm">
+              <button
+                className="flex flex-row w-full justify-end items-center p-3 rounded-b-md bg-background hover:bg-primary-gradient text-primary hover:text-primary fill-primary hover:fill-black transition-all"
+                style={{ gap: '10px' }}
+                onClick={() => setAction(UNDERNAME_TABLE_ACTIONS.CREATE)}
+              >
+                <Plus className="size-4 text-primary fill-black" />
+                Add Undername
+              </button>
+            </div>
+          ) : (
+            <></>
+          )
+        }
       />
-      {showEditUndernameModal && selectedUndername && (
+      {action === UNDERNAME_TABLE_ACTIONS.CREATE && (
+        <AddUndernameModal
+          closeModal={() => {
+            setAction(undefined);
+          }}
+          payloadCallback={(payload: SetRecordPayload) => {
+            setTransactionData(payload);
+            setInteractionType(ANT_INTERACTION_TYPES.SET_RECORD);
+            dispatchTransactionState({
+              type: 'setWorkflowName',
+              payload: ANT_INTERACTION_TYPES.SET_RECORD,
+            });
+            setAction(undefined);
+          }}
+          antId={antId}
+        />
+      )}
+      {action === UNDERNAME_TABLE_ACTIONS.EDIT && selectedUndername && (
         <EditUndernameModal
           antId={new ArweaveTransactionID(antId)}
           undername={selectedUndername}
-          closeModal={() => setShowEditUndernameModal(false)}
-          payloadCallback={(p) => setTransactionData(p)}
+          closeModal={() => setAction(undefined)}
+          payloadCallback={(p) => {
+            setTransactionData(p);
+            setInteractionType(ANT_INTERACTION_TYPES.EDIT_RECORD);
+            dispatchTransactionState({
+              type: 'setWorkflowName',
+              payload: ANT_INTERACTION_TYPES.EDIT_RECORD,
+            });
+            setAction(undefined);
+          }}
         />
       )}
-      {transactionData && wallet?.contractSigner && walletAddress ? (
+      {antId && transactionData && interactionType && isOwner ? (
         <ConfirmTransactionModal
-          interactionType={ANT_INTERACTION_TYPES.EDIT_RECORD}
+          interactionType={interactionType}
           confirm={() =>
-            dispatchANTInteraction({
-              processId: antId,
+            handleInteraction({
               payload: transactionData,
-              workflowName: ANT_INTERACTION_TYPES.EDIT_RECORD,
-              signer: wallet.contractSigner!,
-              owner: walletAddress.toString(),
-              dispatchTransactionState,
-              dispatchArNSState,
-              ao: antAoClient,
-              hyperbeamUrl,
-            }).then(() => {
-              eventEmitter.emit('success', {
-                message: (
-                  <div>
-                    <span>{selectedUndername} successfully updated!</span>
-                  </div>
-                ),
-                name: 'Edit Undername',
-              });
-
-              setTransactionData(undefined);
-              setSelectedUndername(undefined);
-              setShowEditUndernameModal(false);
+              workflowName: interactionType,
+              processId: antId!,
             })
           }
           cancel={() => {
             setTransactionData(undefined);
+            setInteractionType(undefined);
             setSelectedUndername(undefined);
-            setShowEditUndernameModal(false);
           }}
         />
       ) : (

--- a/src/components/devtools/TransferIO.tsx
+++ b/src/components/devtools/TransferIO.tsx
@@ -8,9 +8,6 @@ import eventEmitter from '@src/utils/events';
 import { useState } from 'react';
 
 import ValidationInput from '../inputs/text/ValidationInput/ValidationInput';
-import './styles.css';
-
-// Use styles from NetworkSettings and update the entire rendered component
 
 const inputClass =
   'bg-foreground justify-center items-center outline-none w-full';

--- a/src/components/modals/ConfirmTransactionModal/ConfirmTransactionModal.tsx
+++ b/src/components/modals/ConfirmTransactionModal/ConfirmTransactionModal.tsx
@@ -42,11 +42,7 @@ function ConfirmTransactionModal({
         onNext={confirm}
         footer={
           <div style={{ width: 'fit-content' }}>
-            {/* <TransactionCost
-              fee={fee}
-              showBorder={false}
-              feeWrapperStyle={{ alignItems: 'flex-start' }}
-            /> */}
+            {/* TODO show summary of transaction */}
           </div>
         }
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create a new undername directly from the table for owners.
  * Improved modal handling to support both creating and editing undernames with a unified workflow.

* **Refactor**
  * Streamlined the interaction logic for undername actions, consolidating state management and modal rendering for a smoother user experience.

* **Style**
  * Removed unused CSS import and related comments from the TransferIO component.

* **Documentation**
  * Updated and cleaned up comments in the Confirm Transaction modal for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->