### PR TITLE
fix(manage): do not show any rows when filter returns empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.15.2] - 2025-07-31
+
+### Changed
+
+- Fixed filter functionality in domains table to show no results found message
+  when no results are found.
+
 ## [1.15.1] - 2025-07-31
 
 ### Changed

--- a/src/components/data-display/tables/DomainsTable.tsx
+++ b/src/components/data-display/tables/DomainsTable.tsx
@@ -106,7 +106,8 @@ function filterTableData(filter: string, data: TableData[]): TableData[] {
 const DomainsTable = ({
   domainData,
   loading,
-  filter,
+  filter = '',
+  setFilter,
 }: {
   domainData: {
     names: Record<string, AoArNSNameData>;
@@ -114,6 +115,7 @@ const DomainsTable = ({
   };
   loading: boolean;
   filter?: string;
+  setFilter: (filter: string) => void;
 }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -202,11 +204,8 @@ const DomainsTable = ({
   ]);
 
   useEffect(() => {
-    if (filter) {
-      setFilteredTableData(filterTableData(filter, tableData));
-    } else {
-      setFilteredTableData([]);
-    }
+    const filtered = filterTableData(filter, tableData);
+    setFilteredTableData(filtered);
   }, [filter, tableData]);
   // Define columns for the table
   const columns: ColumnDef<TableData, any>[] = [
@@ -554,13 +553,7 @@ const DomainsTable = ({
       <div className="w-full">
         <TableView
           columns={columns}
-          data={
-            filteredTableData.length
-              ? filteredTableData
-              : tableData.length
-              ? tableData
-              : []
-          }
+          data={filteredTableData}
           isLoading={false}
           noDataFoundText={
             !walletAddress ? (
@@ -581,6 +574,21 @@ const DomainsTable = ({
             ) : loading ? (
               <div className="flex flex-column center white p-[100px]">
                 <Loader message="Loading assets..." />
+              </div>
+            ) : // if a filter is provided, show the no data found message
+            filter && filter.length > 0 ? (
+              <div className="flex flex-column center p-[100px]">
+                <span className="white bold" style={{ fontSize: '16px' }}>
+                  No results found for &apos;{filter}&apos;
+                </span>
+                <button
+                  onClick={() => {
+                    setFilter('');
+                  }}
+                  className="button-secondary center p-[10px] w-fit"
+                >
+                  Clear filter
+                </button>
               </div>
             ) : (
               <div className="flex flex-column center p-[100px]">

--- a/src/components/pages/Manage/Manage.tsx
+++ b/src/components/pages/Manage/Manage.tsx
@@ -61,7 +61,9 @@ function Manage() {
                   />
                   <input
                     className="pl-7 flex bg-background w-full focus:outline-none text-white placeholder:text-dark-grey"
-                    onChange={(e) => setSearch(e.target.value)}
+                    onChange={(e) => {
+                      setSearch(e.target.value);
+                    }}
                     value={search}
                     placeholder="Search your assets"
                   />
@@ -122,6 +124,9 @@ function Manage() {
             domainData={{ names: domains, ants }}
             loading={loadingArnsState}
             filter={search}
+            setFilter={(filter) => {
+              setSearch(filter);
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
The filter would show ALL rows when no filtered results would show - this is counterintuitive. This PR changes the behavior to show a `No results found for {filter}` message along with a `Clear Filter` button to easily reset the filter.

Before:
<img width="1641" height="613" alt="image" src="https://github.com/user-attachments/assets/31589273-5983-4373-9227-4be81e3bdf19" />

After:
<img width="1625" height="642" alt="image" src="https://github.com/user-attachments/assets/982b61ce-0a70-4106-9e7b-704f02c04d79" />
