### PR TITLE
feat(manage): open row on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.15.3] - 2025-07-31
+
+### Changed
+
+- Open undername table on row click in domains table.
+
 ## [1.15.2] - 2025-07-31
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.15.2",
+  "version": "1.15.3",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/data-display/tables/DomainsTable.tsx
+++ b/src/components/data-display/tables/DomainsTable.tsx
@@ -555,6 +555,12 @@ const DomainsTable = ({
           columns={columns}
           data={filteredTableData}
           isLoading={false}
+          onRowClick={(rowData, tableRow) => {
+            if (tableRow) {
+              tableRow.toggleExpanded();
+            }
+            return rowData;
+          }}
           noDataFoundText={
             !walletAddress ? (
               <div className="flex flex-column text-medium center white p-[100px] box-border gap-[20px]">

--- a/src/components/data-display/tables/TableView.tsx
+++ b/src/components/data-display/tables/TableView.tsx
@@ -48,7 +48,7 @@ const TableView = <T, S>({
   defaultSortingState: ColumnSort;
   isLoading: boolean;
   noDataFoundText?: ReactNode;
-  onRowClick?: (row: T) => T;
+  onRowClick?: (row: T, tableRow?: Row<T>) => T;
   getSubRows?: (row: T, index: number) => T[] | undefined;
   renderSubComponent?: (props: { row: Row<T> }) => ReactNode;
   tableClass?: string;
@@ -175,7 +175,20 @@ const TableView = <T, S>({
                       onRowClick ? 'cursor-pointer' : ''
                     }`}
                     onClick={
-                      onRowClick ? () => onRowClick(row.original) : undefined
+                      onRowClick
+                        ? (e) => {
+                            console.log(e.target);
+                            // Prevent row click if a button inside the row was clicked
+                            if (
+                              e.target instanceof HTMLElement &&
+                              (e.target.closest('button') ||
+                                e.target.tagName === 'BUTTON')
+                            ) {
+                              return;
+                            }
+                            onRowClick(row.original, row);
+                          }
+                        : undefined
                     }
                   >
                     {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now open the undername table by clicking on a row in the domains table.

* **Documentation**
  * Updated the changelog to reflect the new feature.

* **Chores**
  * Updated the app version to 1.15.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->