### PR TITLE
fix: default to arweave.net for Arweave.app and Metamask connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.15.4] - 2025-08-04
+
+### Fixed
+
+- Default to arweave.net for Arweave.app and Metamask wallets
+
 ## [1.15.3] - 2025-07-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 
 - Default to arweave.net for Arweave.app and Metamask wallets
 
+### Changed
+
+- Remove wallet-based gateway config and only use app-based gateway config
+
 ## [1.15.3] - 2025-07-31
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.15.3",
+  "version": "1.15.4",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
@@ -1,4 +1,3 @@
-import { AOProcess, ARIO } from '@ar.io/sdk/web';
 import {
   BeaconWalletConnector,
   EthWalletConnector,
@@ -10,8 +9,6 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useConfig } from 'wagmi';
 
-import { dispatchNewGateway } from '../../../state/actions';
-import { useGlobalState } from '../../../state/contexts/GlobalState';
 import { useWalletState } from '../../../state/contexts/WalletState';
 import { AoAddress, ArNSWalletConnector } from '../../../types';
 import eventEmitter from '../../../utils/events';
@@ -27,8 +24,6 @@ import './styles.css';
 
 function ConnectWalletModal(): JSX.Element {
   const modalRef = useRef<HTMLDivElement>(null);
-  const [{ arioProcessId, aoClient, turboNetwork }, dispatchGlobalState] =
-    useGlobalState();
   const [
     { wallet, walletAddress, walletStateInitialized },
     dispatchWalletState,
@@ -87,22 +82,6 @@ function ConnectWalletModal(): JSX.Element {
     try {
       setConnecting(true);
       await walletConnector.connect();
-      const arweaveGate = await walletConnector.getGatewayConfig();
-      const contract = ARIO.init({
-        paymentUrl: turboNetwork.PAYMENT_URL,
-        process: new AOProcess({
-          processId: arioProcessId,
-          ao: aoClient,
-        }),
-        signer: walletConnector.turboSigner!,
-      });
-      if (arweaveGate?.host) {
-        await dispatchNewGateway(
-          arweaveGate.host,
-          contract,
-          dispatchGlobalState,
-        );
-      }
 
       const address = await walletConnector.getWalletAddress();
       dispatchWalletState({

--- a/src/services/wallets/ArweaveAppWalletConnector.ts
+++ b/src/services/wallets/ArweaveAppWalletConnector.ts
@@ -2,7 +2,6 @@ import { TurboArNSSigner } from '@ar.io/sdk/web';
 import { TokenType } from '@ardrive/turbo-sdk';
 import { ARWEAVE_APP_API } from '@src/utils/constants';
 import { ArweaveAppError } from '@src/utils/errors';
-import { ApiConfig } from 'arweave/node/lib/api';
 import { ReactiveConnector } from 'node_modules/arweave-wallet-connector/lib/browser/Reactive';
 
 import { WANDER_UNRESPONSIVE_ERROR } from '../../components/layout/Notifications/Notifications';
@@ -79,13 +78,5 @@ export class ArweaveAppWalletConnector implements ArNSWalletConnector {
     const address =
       await this._wallet.namespaces.arweaveWallet.getActiveAddress();
     return new ArweaveTransactionID(address);
-  }
-
-  async getGatewayConfig(): Promise<ApiConfig> {
-    return {
-      host: 'arweave.net',
-      port: 443,
-      protocol: 'https',
-    };
   }
 }

--- a/src/services/wallets/ArweaveAppWalletConnector.ts
+++ b/src/services/wallets/ArweaveAppWalletConnector.ts
@@ -83,7 +83,7 @@ export class ArweaveAppWalletConnector implements ArNSWalletConnector {
 
   async getGatewayConfig(): Promise<ApiConfig> {
     return {
-      host: 'ar-io.dev',
+      host: 'arweave.net',
       port: 443,
       protocol: 'https',
     };

--- a/src/services/wallets/BeaconWalletConnector.ts
+++ b/src/services/wallets/BeaconWalletConnector.ts
@@ -4,7 +4,6 @@ import { BeaconError } from '@src/utils/errors';
 import eventEmitter from '@src/utils/events';
 import WalletClient from '@vela-ventures/ao-sync-sdk';
 import { PermissionType } from 'arconnect';
-import { ApiConfig } from 'arweave/node/lib/api';
 
 import { ArNSWalletConnector, WALLET_TYPES } from '../../types';
 import { ArweaveTransactionID } from '../arweave/ArweaveTransactionID';
@@ -59,11 +58,6 @@ export class BeaconWalletConnector implements ArNSWalletConnector {
     return await this._wallet
       ?.getActiveAddress()
       .then((res) => new ArweaveTransactionID(res));
-  }
-
-  async getGatewayConfig(): Promise<ApiConfig> {
-    const config = await this._wallet?.getArweaveConfig();
-    return config as unknown as ApiConfig;
   }
 
   async updatePermissions(): Promise<void> {

--- a/src/services/wallets/EthWalletConnector.ts
+++ b/src/services/wallets/EthWalletConnector.ts
@@ -132,7 +132,7 @@ export class EthWalletConnector implements ArNSWalletConnector {
 
   async getGatewayConfig(): Promise<ApiConfig> {
     return {
-      host: 'ar-io.dev',
+      host: 'arweave.net',
       port: 443,
       protocol: 'https',
     };

--- a/src/services/wallets/EthWalletConnector.ts
+++ b/src/services/wallets/EthWalletConnector.ts
@@ -7,7 +7,6 @@ import {
 import { TokenType } from '@ardrive/turbo-sdk';
 import { createData } from '@dha-team/arbundles';
 import { MetamaskError } from '@src/utils/errors';
-import { ApiConfig } from 'arweave/node/lib/api';
 import { hashMessage, parseEther, recoverPublicKey, toBytes } from 'viem';
 import { mainnet } from 'viem/chains';
 import { Config, Connector } from 'wagmi';
@@ -128,14 +127,6 @@ export class EthWalletConnector implements ArNSWalletConnector {
       throw new MetamaskError('No address found');
     }
     return address;
-  }
-
-  async getGatewayConfig(): Promise<ApiConfig> {
-    return {
-      host: 'arweave.net',
-      port: 443,
-      protocol: 'https',
-    };
   }
 
   async submitNativeTransaction(

--- a/src/services/wallets/WanderWalletConnector.ts
+++ b/src/services/wallets/WanderWalletConnector.ts
@@ -3,7 +3,6 @@ import { TokenType } from '@ardrive/turbo-sdk';
 import { WalletNotInstalledError, WanderError } from '@src/utils/errors';
 import eventEmitter from '@src/utils/events';
 import { PermissionType } from 'arconnect';
-import { ApiConfig } from 'arweave/node/lib/api';
 
 import { WANDER_UNRESPONSIVE_ERROR } from '../../components/layout/Notifications/Notifications';
 import { ArNSWalletConnector, WALLET_TYPES } from '../../types';
@@ -97,13 +96,6 @@ export class WanderWalletConnector implements ArNSWalletConnector {
         ?.getActiveAddress()
         .then((res) => new ArweaveTransactionID(res)),
     );
-  }
-
-  async getGatewayConfig(): Promise<ApiConfig> {
-    const config = await this.safeWanderApiExecutor(
-      this._wallet?.getArweaveConfig,
-    );
-    return config as unknown as ApiConfig;
   }
 
   async updatePermissions(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ import {
   TurboArNSSigner,
 } from '@ar.io/sdk/web';
 import { TokenType } from '@ardrive/turbo-sdk';
-import { ApiConfig } from 'arweave/web/lib/api';
 import type { Dispatch, SetStateAction } from 'react';
 
 import { AntDetailKey } from './components/cards/ANTCard/ANTCard';
@@ -86,7 +85,6 @@ export interface ArNSWalletConnector {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   getWalletAddress(): Promise<AoAddress>;
-  getGatewayConfig(): Promise<ApiConfig>;
   contractSigner?: ContractSigner;
   on?: (event: string, listener: (data: any) => void) => Promise<void>;
   off?: (event: string, listener: (data: any) => void) => Promise<void>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Arweave gateway to "arweave.net" for Arweave.app and Metamask wallets to improve connectivity.

* **Chores**
  * Incremented version number to 1.15.4.
  * Added a new release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->