### PR TITLE
refactor: type primary name query

### DIFF
--- a/src/hooks/usePrimaryName.tsx
+++ b/src/hooks/usePrimaryName.tsx
@@ -1,22 +1,21 @@
+import { AoPrimaryName } from '@ar.io/sdk/web';
 import { useGlobalState, useWalletState } from '@src/state';
+import { queryKeys } from '@src/utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export function usePrimaryName() {
   const [{ walletAddress }] = useWalletState();
   const [{ arioContract, arioProcessId }] = useGlobalState();
-  return useQuery({
-    queryKey: [
-      'primary-name',
+  return useQuery<AoPrimaryName | null>({
+    queryKey: queryKeys.primaryName(
       walletAddress?.toString(),
-      arioProcessId.toString(),
-    ],
+      arioProcessId?.toString(),
+    ),
     queryFn: async () => {
       if (!walletAddress)
         throw new Error('Must be connected to retrieve primary name');
-      const primaryNameData = await arioContract
-        .getPrimaryName({
-          address: walletAddress?.toString(),
-        })
+      const primaryNameData = await arioContract!
+        .getPrimaryName({ address: walletAddress })
         .catch(() => {
           // no name returned, return null
           return null;

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -18,6 +18,7 @@ import {
 import { del, get, set } from 'idb-keyval';
 
 import { isArweaveTransactionID } from '.';
+import type { QueryKey } from './queryKeys';
 
 /**
  * Creates an Indexed DB persister
@@ -35,6 +36,12 @@ export function createIDBPersister(idbValidKey: IDBValidKey = 'reactQuery') {
       await del(idbValidKey);
     },
   } as Persister;
+}
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryKey: QueryKey;
+  }
 }
 
 export const queryClient = new QueryClient({

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -1,0 +1,10 @@
+import type { QueryKey as BaseQueryKey } from '@tanstack/react-query';
+
+export const queryKeys = {
+  primaryName: (walletAddress?: string, arioProcessId?: string) =>
+    ['primary-name', walletAddress, arioProcessId] as const,
+} as const;
+
+export type QueryKey =
+  | ReturnType<(typeof queryKeys)[keyof typeof queryKeys]>
+  | BaseQueryKey;


### PR DESCRIPTION
## Summary
- introduce centralized queryKeys and register typed query client
- use typed primary-name key in usePrimaryName and PrimaryNameModal

## Testing
- `yarn test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_b_689e15c27db4832eb6b435577804c8d5