### PR TITLE
feat: use shared credits on turbo arns pruchase

### DIFF
--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -330,6 +330,9 @@ function Checkout() {
             : paymentMethod === 'credits'
             ? 'turbo'
             : fundingSource,
+        paidBy: creditsBalance?.receivedApprovals.map(
+          (approval) => approval.payingAddress,
+        ),
         turboArNSClient: turbo,
         hyperbeamUrl,
       });

--- a/src/components/pages/Transaction/TransactionReview.tsx
+++ b/src/components/pages/Transaction/TransactionReview.tsx
@@ -126,6 +126,10 @@ function TransactionReview() {
         scheduler: aoNetwork.ARIO.SCHEDULER,
         fundFrom: fundingSource,
         hyperbeamUrl,
+        // TODO: Do we need paidBy from turbo balance in this workflow
+        // paidBy: creditsBalance?.receivedApprovals.map(
+        //   (approval) => approval.payingAddress,
+        // ),
       });
     } catch (error) {
       eventEmitter.emit('error', error);

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -37,6 +37,7 @@ export default async function dispatchArIOInteraction({
   scheduler = DEFAULT_SCHEDULER_ID,
   fundFrom,
   turboArNSClient,
+  paidBy,
 }: {
   payload: Record<string, any>;
   workflowName: ARNS_INTERACTION_TYPES;
@@ -50,6 +51,7 @@ export default async function dispatchArIOInteraction({
   scheduler?: string;
   fundFrom?: FundFrom | 'fiat';
   turboArNSClient?: TurboArNSClient;
+  paidBy?: string[];
 }): Promise<ContractInteraction> {
   let result: AoMessageResult<MessageResult | unknown> | undefined = undefined;
   try {
@@ -125,6 +127,7 @@ export default async function dispatchArIOInteraction({
             processId: antProcessId,
             fundFrom,
             referrer: APP_NAME,
+            paidBy,
           });
           result = buyRecordResult;
         }
@@ -156,6 +159,7 @@ export default async function dispatchArIOInteraction({
               years: payload.years,
               fundFrom: originalFundFrom,
               referrer: APP_NAME,
+              paidBy,
             },
             WRITE_OPTIONS,
           );
@@ -181,6 +185,7 @@ export default async function dispatchArIOInteraction({
               increaseCount: payload.qty,
               fundFrom: originalFundFrom,
               referrer: APP_NAME,
+              paidBy,
             },
             WRITE_OPTIONS,
           );
@@ -271,6 +276,7 @@ export default async function dispatchArIOInteraction({
               name: payload.name,
               fundFrom: originalFundFrom,
               referrer: APP_NAME,
+              paidBy,
             },
             WRITE_OPTIONS,
           );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Checkout now supports choosing approved payer addresses from your credits balance. When available, multiple approved payers are automatically included to fund the transaction.
  - Applies to record purchases, lease extensions, undername limit increases, and upgrades for a smoother payment experience.
  - Fiat payment flow remains unchanged.
  - Transaction Review behavior is unchanged for now (preparatory notes added with no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->