### PR TITLE
fix(PE-8533): disable arns actions if not owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.24.1] - 2025-09-08
+
+### Fixed
+
+- Hide undernames table actions for non-authorized users
+
 ## [1.24.0] - 2025-09-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.1",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/data-display/tables/UndernamesTable.tsx
+++ b/src/components/data-display/tables/UndernamesTable.tsx
@@ -167,7 +167,7 @@ const UndernamesTable = ({
           targetId: record.transactionId,
           ttlSeconds: record.ttlSeconds,
           priority: record.index,
-          action: (
+          action: isAuthorized ? (
             <span className="flex justify-end pr-3 gap-3">
               {isOwner && (
                 <Tooltip
@@ -273,7 +273,7 @@ const UndernamesTable = ({
                 <></>
               )}
             </span>
-          ),
+          ) : null,
         };
         newTableData.push(data as TableData);
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid edit/delete actions in the Undernames table for non-authorized users. Only authorized users now see and can access these controls; behavior for authorized users remains unchanged.

* **Documentation**
  * Updated changelog with version 1.24.1 entry detailing the fix.

* **Chores**
  * Bumped app version to 1.24.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->