### PR TITLE
feat(banner): add Hyperbeam migration warning banner

### DIFF
--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -14,8 +14,9 @@ function Layout() {
 
   const homeOrRegister =
     location.pathname === '/' || location.pathname.startsWith('/register');
-  const julyEigth2024 = new Date('2024-07-08T00:00:00Z').getTime();
-  const showBanner = homeOrRegister && Date.now() < julyEigth2024;
+  // TODO: Remove banner once Hyperbeam migration is complete and purchases are re-enabled
+  const hyperbeamMigrationEnd = new Date('2026-03-02T00:00:00Z').getTime();
+  const showBanner = homeOrRegister && Date.now() < hyperbeamMigrationEnd;
 
   return (
     <div

--- a/src/components/layout/Layout/TopBanner.tsx
+++ b/src/components/layout/Layout/TopBanner.tsx
@@ -1,19 +1,23 @@
+import { useIsMobile } from '@src/hooks';
 import { ARIO_DISCORD_LINK } from '@src/utils/constants';
 import { Link } from 'react-router-dom';
 
 const TopBanner = () => {
+  const isMobile = useIsMobile();
+
   return (
     <div
       style={{
         textAlign: 'center',
-        backgroundColor: 'var(--success-green)',
+        backgroundColor: 'var(--accent)',
         color: 'var(--text-black)',
-        padding: '12px 18px',
+        padding: isMobile ? '12px 15px' : '12px 18px',
         fontSize: '14px',
       }}
     >
-      AO migration is complete! All functionality should now be returned to
-      normal. Please let us know in{' '}
+      ArNS name purchases and upgrades are temporarily unavailable during the
+      migration to Hyperbeam (AO Mainnet). Existing names can still be modified.
+      Follow updates in{' '}
       <Link
         to={ARIO_DISCORD_LINK}
         target="_blank"
@@ -27,8 +31,8 @@ const TopBanner = () => {
         }}
       >
         Discord
-      </Link>{' '}
-      if you encounter any bugs or issues.
+      </Link>
+      .
     </div>
   );
 };


### PR DESCRIPTION
Display a warning banner on home and register pages informing users that ArNS name purchases and upgrades are temporarily unavailable during the Hyperbeam (AO Mainnet) migration. Existing names can still be modified.

Banner will automatically hide after March 2, 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-responsive design to banner layout.

* **Style**
  * Updated banner background color.
  * Modified banner message to communicate temporary service unavailability during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->