### PR TITLE
fix: scope purchase disable flag and update gateway URL routing

### DIFF
--- a/404_page/index.html
+++ b/404_page/index.html
@@ -5,12 +5,12 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+      href="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!-- tailwind css script -->
-    <script src="https://arweave.net/RjXXBjP2GCZZUg4gSW1Hyr9GtLG-o59QCHrKiITtpQw"></script>
+    <script src="https://turbo-gateway.com/RjXXBjP2GCZZUg4gSW1Hyr9GtLG-o59QCHrKiITtpQw"></script>
     <script>
       tailwind.config = {
         theme: {
@@ -86,7 +86,7 @@
       class="sm:w-full absolute md:w-fit md:relative h-full"
     >
       <img
-        src="https://arweave.net/ZUxr5bSRFh-D8zF8Y8Bkq64QskV8YCZMpJuooqFY-aY"
+        src="https://turbo-gateway.com/ZUxr5bSRFh-D8zF8Y8Bkq64QskV8YCZMpJuooqFY-aY"
         alt="astronaut"
         class="sm:w-full md:w-fit h-full"
       />
@@ -97,7 +97,7 @@
       >
         <img
           class="invisible md:visible rounded bg-surface p-4 h-fit relative -right-1/2"
-          src="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+          src="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
           alt="logo"
           width="65px"
           height="65px"
@@ -111,7 +111,7 @@
       style="flex-wrap: wrap"
     >
       <img
-        src="https://arweave.net/At1eNgYl43Rc6XhMRo88blSSUv84rFMkPaMklN143zQ"
+        src="https://turbo-gateway.com/At1eNgYl43Rc6XhMRo88blSSUv84rFMkPaMklN143zQ"
         class="hidden sm:block absolute top-0 right-0 h-full"
         draggable="false"
       />
@@ -172,7 +172,7 @@
         </a>
         <img
           class="md:hidden mx-auto absolute right-0 left-0 rounded bg-surface p-3 h-fit md:relative"
-          src="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+          src="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
           alt="logo"
           width="50px"
           height="50px"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.30.1] - 2026-04-13
+
+### Changed
+
+- Updated gateway URLs: ArNS name links use ar.io, transaction/data fetching uses turbo-gateway.com, GraphQL remains on arweave.net
+- Allow lease extensions and undername upgrades when ArNS purchases are disabled (only new name registrations and name upgrades that create new ANTs are blocked)
+
 ## [1.30.0] - 2026-03-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,359 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+This is a React application for the Arweave Name System (ArNS) Registry,
+allowing users to search for and purchase Names. Built with Vite, React 18,
+TypeScript, and TailwindCSS.
+
+## Development Commands
+
+### Setup and Running
+
+```bash
+yarn                  # Install dependencies
+yarn dev              # Start development server (sets NODE_ENV=prod, VITE_GITHUB_HASH=local)
+yarn build            # Build for production (includes TypeScript compilation and Vite build with increased memory)
+yarn preview          # Preview production build
+```
+
+### Testing
+
+```bash
+yarn test                    # Run Jest unit tests
+yarn test:updateSnapshot     # Update Jest snapshots
+yarn test:coverage          # Run tests with coverage report (80% threshold for branches/functions/lines)
+yarn test:playwright        # Run Playwright e2e tests
+```
+
+To run a single test file:
+
+```bash
+# Cross-platform (recommended)
+yarn cross-env NODE_ENV=test jest path/to/test.test.ts
+
+# Or use npx
+npx cross-env NODE_ENV=test jest path/to/test.test.ts
+```
+
+### Code Quality
+
+```bash
+yarn lint:check      # Check for linting errors with Biome
+yarn lint:fix        # Auto-fix linting errors with Biome
+yarn format:check    # Check code formatting with Biome
+yarn format:fix      # Auto-format code with Biome
+yarn pre-commit      # Run lint-staged (triggered by Husky pre-commit hook)
+```
+
+### Other Commands
+
+```bash
+yarn storybook           # Start Storybook dev server on port 6006
+yarn build-storybook     # Build Storybook
+yarn docs:serve          # Generate and serve TypeDoc documentation
+yarn clean               # Remove dist directory
+```
+
+## Architecture
+
+### State Management
+
+The application uses React Context API with reducer pattern for state
+management. There are multiple domain-specific contexts, each with their own
+reducer:
+
+- **GlobalState** (`src/state/contexts/GlobalState.tsx`): Gateway configuration,
+  AO network settings, Turbo network configuration, ArIO contract, blockchain
+  height, process IDs
+- **WalletState**: Wallet connection, balance, address
+- **ArNSState**: ArNS records and domain-related state
+- **TransactionState**: Transaction tracking and history
+- **RegistrationState**: Domain registration flow state
+- **ModalState**: Modal visibility and content
+
+All contexts are initialized in `src/main.tsx` with a nested provider structure.
+State is persisted to localStorage for settings via the `useSyncSettings` hook.
+
+### Data Layer
+
+**Arweave Data Providers** (`src/services/arweave/`):
+
+- `ArweaveCompositeDataProvider`: Main data provider that aggregates multiple
+  sources
+- `SimpleArweaveDataProvider`: Basic Arweave data fetching
+
+**React Query** (`@tanstack/react-query`):
+
+- Used extensively for server state management via custom hooks in `src/hooks/`
+- Configured in `src/utils/network.ts` with `queryClient`
+- IndexedDB persister available but currently commented out in main.tsx
+
+**Custom Hooks** (`src/hooks/`):
+
+- Follow the naming pattern `use<Feature>.tsx`
+- Examples: `useArNSRecord`, `useGateways`, `useTurboArNSClient`,
+  `usePrimaryName`
+- Encapsulate data fetching, transformations, and domain logic
+
+### AO Integration
+
+The app integrates with the AO (Arweave Operating System) ecosystem:
+
+- **AR.IO SDK** (`@ar.io/sdk/web`): Primary interface for ArNS operations,
+  gateways, and ArIO contracts
+- **AO Connect** (`@permaweb/aoconnect`): AO process communication
+- Process IDs configured for ARIO and ANT Registry
+- ANT (Arweave Name Token) operations handled via `AoANTHandler`
+
+### Routing
+
+Hash-based routing using React Router v6 (`createHashRouter`):
+
+- Routes defined in `src/App.tsx` with lazy loading for pages
+- Main routes: `/`, `/register`, `/manage`, `/manage/:domain`,
+  `/undernames/:domain`, `/ant/:antId`, `/prices`, `/settings/*`
+- Sentry integration via `wrapCreateBrowserRouter`
+
+### Wallet Integration
+
+Supports multiple wallet types via:
+
+**Arweave Wallets**:
+- **Wander** (formerly ArConnect) - Primary Arweave wallet (`arconnect`)
+- **Arweave.app** (`arweave-wallet-connector`)
+- **Beacon** - Mobile wallet connector
+
+**Ethereum Wallets** (via Rainbow Kit + Wagmi):
+- **Rainbow Kit** (`@rainbow-me/rainbowkit`) - Multi-wallet modal supporting 100+ wallets
+- **Wagmi** for Ethereum wallet state and interactions
+- Configured in `src/main.tsx` with `getDefaultConfig()`
+- Supported chains: Ethereum mainnet, Base, and Polygon
+- WalletConnect Project ID: hardcoded in `src/utils/constants.ts`
+
+**Wallet Connectors** (`src/services/wallets/`):
+- `WanderWalletConnector` - Wander/ArConnect
+- `ArweaveAppWalletConnector` - arweave.app
+- `BeaconWalletConnector` - Beacon mobile
+- `EthWalletConnector` - Generic Ethereum (works with any wagmi connector)
+
+**Key Types** (`src/types.ts`):
+- `ArNSWalletConnector` interface defines the common contract for all wallets
+- `WALLET_TYPES` enum: `WANDER`, `ARWEAVE_APP`, `ETHEREUM`, `BEACON`
+- `AoAddress` = `EthAddress | ArweaveTransactionID` (union type for all addresses)
+- `EthAddress` = `` `0x${string}` `` (Ethereum address format)
+- Wallet type persisted to `localStorage` as `walletType` key
+
+Wallet state managed in `WalletState` context with reconnection logic for each
+wallet type
+
+### Payment Systems
+
+- **Turbo SDK** (`@ardrive/turbo-sdk`): Credits and uploads
+  - Web-specific upload implementation uses `@ardrive/turbo-sdk/web`
+  - Custom type definitions in `src/types/turbo.ts` provide type safety for web
+    upload operations (SDK doesn't export web-specific types)
+  - Image uploads handled via `useUploadArNSLogo` hook with progress tracking
+- **Stripe** (`@stripe/react-stripe-js`, `@stripe/stripe-js`): Fiat payments
+- Stripe initialized in App.tsx with network-specific publishable key
+
+### Styling
+
+- **TailwindCSS** with custom configuration (`tailwind.config.mjs`)
+- **Ant Design** (`antd`) for UI components with custom theming
+- **Radix UI** for headless components (checkbox, radio, select, switch)
+- **Framer Motion** for animations
+- CSS modules pattern: component folders contain `styles.css`
+
+## File Organization Rules
+
+### Components
+
+- Create a folder for each component containing:
+  - `<ComponentName>.tsx` - exported component file
+  - `__tests__/` - testing folder
+  - `styles.css` - component styles
+- Test files named: `<component-name>.test.ts`
+
+### Utilities
+
+- Place in `src/utils/` folder with its own testing folder
+- Path alias: `@src/utils/*`
+- Image utilities in `src/utils/imageUtils.ts` for validation, compression, and
+  dimension checking
+
+### Types
+
+- TypeScript type definitions in `src/types/` for external libraries that don't
+  export needed types
+- Example: `src/types/turbo.ts` provides web-specific Turbo SDK types
+
+### Images
+
+- Location: `assets/images/<theme-type>/`
+- `dark/` - dark mode specific images
+- `light/` - light mode specific images
+- `common/` - shared across themes
+
+### Translations
+
+- Location: `assets/translations/`
+- Named: `<native-languages-name>.json`
+
+## Error Handling and Notifications
+
+### Event Emitter Pattern
+
+Import `eventEmitter` from `src/utils/events.ts` to emit notifications.
+
+### Error Types (`src/utils/errors.ts`)
+
+- **NotificationOnlyError**: Shows notification but does NOT emit to Sentry
+  - Subclasses: `ValidationError`, `WanderError`, `ArweaveAppError`,
+    `MetamaskError`, `EthereumWalletError`, `BeaconError`, `InsufficientFundsError`,
+    `WalletNotInstalledError`, `UpgradeRequiredError`, `ANTStateError`
+- **Standard Error**: Automatically reported to Sentry for unhandled errors
+
+Use `NotificationOnlyError` for expected/user-facing errors. Use standard
+`Error` for unexpected errors that should be tracked.
+
+## Build and Deployment
+
+### Production Build
+
+- TypeScript compilation followed by Vite build
+- Source maps enabled
+- Sentry plugin integration for error tracking (disabled when deploying to
+  Permaweb)
+- Large memory allocation: `--max-old-space-size=32768`
+
+### Environment Variables
+
+- Defined in Vite config, not exposed via process.env for security
+- Key variables: `VITE_ARWEAVE_HOST`, `VITE_ARWEAVE_GRAPHQL_URL`,
+  `VITE_HYPERBEAM_URL`, `VITE_SENTRY_*`, `VITE_ARNS_NAME`
+
+### Arweave Deployment
+
+```bash
+yarn publish:arweave  # Deploys to Arweave using permaweb-deploy with ARNS name
+```
+
+### CI/CD
+
+Workflows in `.github/workflows/`:
+
+- `build_and_test.yml` - Build and test on PR
+- `pr.yml` - PR checks
+- `staging_deploy.yml` - Staging deployments
+- `production.yml` - Production deployments
+
+## Path Aliases
+
+Configured in `tsconfig.json` and `vite.config.ts`:
+
+- `@src/*` → `./src/*`
+- `@tests/*` → `./tests/*`
+
+## Git Hooks
+
+- **pre-commit**: Runs `lint-staged` which lints TypeScript files and formats
+  all files
+- **commit-msg**: Uses `commitlint` with conventional commit format
+  - Standard types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+  - No max length restrictions on header or body
+
+## Feature Flags
+
+### ArNS Name Purchases (`ARNS_PURCHASES_DISABLED`)
+
+When `true`, flows that create new ANTs are blocked: new name registration
+(`BUY_RECORD`) and upgrade to permabuy (`UPGRADE_NAME`). Affected components:
+Register, Checkout, HomeSearch, ReturnedNamesTable, and the "Permanently Buy"
+tab on ExtendLease. Disabled buttons show a tooltip from
+`ARNS_PURCHASES_DISABLED_TOOLTIP`.
+
+Flows that operate on existing ANTs are **not** affected: lease extensions
+(`EXTEND_LEASE`) and undername upgrades (`INCREASE_UNDERNAMES`).
+
+- **Location:** `src/utils/constants.ts`
+- **To disable purchases:** set `ARNS_PURCHASES_DISABLED = true`
+- **To enable purchases:** set `ARNS_PURCHASES_DISABLED = false`
+
+No other code changes are required; the flag is read at runtime.
+
+## Gateway URL Routing
+
+Different gateway domains are used for different purposes:
+
+- **GraphQL** (`arweave.net`): Arweave L1 GraphQL queries — `ARWEAVE_HOST`,
+  `ARWEAVE_GRAPHQL_URL`, NetworkSettings suConnect
+- **Transaction/data fetching** (`turbo-gateway.com`): Arweave data retrieval —
+  `DEFAULT_ARWEAVE`, `TURBO.GATEWAY_URL`, static HTML asset URLs
+- **ArNS name links** (`ar.io`): ArNS domain resolution —
+  `NETWORK_DEFAULTS.ARNS.HOST`, GlobalState `gateway` default
+
+When adding new URLs, use the correct domain for the purpose. Do not use
+`arweave.net` for data fetching or `turbo-gateway.com` for ArNS links.
+
+## Important Implementation Notes
+
+### Smartweave Contract Deployment
+
+Contracts are deployed manually to avoid the Warp Deploy Plugin which doesn't
+implement tree shaking. This saves ~2MB in build size. Switch to Warp core
+package deployment when tree shaking is supported or when deployment becomes
+more complex (e.g., L2 usage).
+
+### ANT Version Compatibility
+
+Minimum ANT version: 16 (`MIN_ANT_VERSION` in `src/utils/constants.ts`) All
+workflows (reassign, release, etc.) must be compatible with this version.
+
+### Node Polyfills
+
+Vite is configured with `vite-plugin-node-stdlib-browser` for Node.js polyfills
+required by Arweave libraries.
+
+### TypeScript Configuration
+
+- Target: ESNext
+- Module resolution: bundler
+- Strict mode enabled
+- No emit (Vite handles compilation)
+
+### Ethereum Wallet Signer Architecture
+
+The `EthWalletConnector` creates two types of signers for Ethereum wallets:
+
+- **Turbo Signer** (`TurboArNSSigner`): For logo uploads via Turbo SDK
+- **AO Signer** (`ContractSigner`): For ArNS/ANT interactions via AO messaging
+
+Both use `InjectedEthereumSigner` from AR.IO SDK. Public key is derived by:
+1. Signing message: "Sign this message to connect to ArNS.app"
+2. Recovering public key from signature using `viem/recoverPublicKey`
+3. Storing in signer for subsequent AO data item signing
+
+### Turbo SDK Type Safety
+
+The Turbo SDK's web implementation has different type signatures than its
+Node.js counterpart. To maintain type safety:
+
+- Import types directly from `@ardrive/turbo-sdk/web` (TurboUploadDataItemResponse,
+  TurboUploadEventsAndPayloads, DataItemOptions)
+- `src/types/turbo.ts` re-exports these types for convenience
+- Use type assertions (`as unknown as TurboWebAuthenticatedClient`) when creating
+  TurboFactory.authenticated clients for web upload operations since the web
+  implementation's `uploadFile` method accepts `File` objects directly
+- The `useUploadArNSLogo` hook (src/hooks/useUploadArNSLogo.tsx) demonstrates
+  proper usage pattern for web uploads with progress tracking
+
+### Rainbow Kit / Wagmi Configuration
+
+Rainbow Kit is configured in `src/main.tsx` with `getDefaultConfig()`:
+- WalletConnect Project ID is hardcoded in `src/utils/constants.ts` as `WALLETCONNECT_PROJECT_ID`
+- Supported chains: Ethereum mainnet, Base, and Polygon
+- The provider hierarchy is: WagmiProvider → QueryClientProvider → RainbowKitProvider → App contexts

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn test
 
 ### ArNS name purchases (`ARNS_PURCHASES_DISABLED`)
 
-When enabled, all ArNS name purchase flows are blocked: Register (buy new name), Checkout (pay), Extend Lease, Increase Undernames, and Register buttons on the home search and returned names table. Disabled buttons show a tooltip: *"ArNS Name purchases currently disabled for duration of mainnet migration."*
+When enabled, new ArNS name purchase flows are blocked: Register (buy new name), Checkout (pay), and Register buttons on the home search and returned names table. Disabled buttons show a tooltip explaining the temporary restriction. Lease extensions and undername upgrades for existing names are **not** affected.
 
 - **Location:** `src/utils/constants.ts`
 - **To disable purchases (block users):** set `ARNS_PURCHASES_DISABLED = true`

--- a/landing_page/index.html
+++ b/landing_page/index.html
@@ -5,11 +5,11 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+      href="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <script src="https://arweave.net/RjXXBjP2GCZZUg4gSW1Hyr9GtLG-o59QCHrKiITtpQw"></script>
+    <script src="https://turbo-gateway.com/RjXXBjP2GCZZUg4gSW1Hyr9GtLG-o59QCHrKiITtpQw"></script>
     <script>
       tailwind.config = {
         theme: {
@@ -79,7 +79,7 @@
   >
     <div id="bull-image" class="sm:w-full absolute md:w-fit md:relative h-full">
       <img
-        src="https://arweave.net/dYuIOAQ-ON40ICTXhwgnuaZty1Yulb9ZPgrJ6_WH6Mw"
+        src="https://turbo-gateway.com/dYuIOAQ-ON40ICTXhwgnuaZty1Yulb9ZPgrJ6_WH6Mw"
         alt="bull"
         class="sm:w-full md:w-fit h-full"
       />
@@ -90,7 +90,7 @@
       >
         <img
           class="invisible md:visible rounded bg-surface p-4 h-fit relative -right-1/2"
-          src="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+          src="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
           alt="logo"
           width="65px"
           height="65px"
@@ -104,7 +104,7 @@
       style="flex-wrap: wrap"
     >
       <img
-        src="https://arweave.net/At1eNgYl43Rc6XhMRo88blSSUv84rFMkPaMklN143zQ"
+        src="https://turbo-gateway.com/At1eNgYl43Rc6XhMRo88blSSUv84rFMkPaMklN143zQ"
         class="hidden sm:block absolute top-0 right-0 h-full"
         draggable="false"
       />
@@ -165,7 +165,7 @@
         </a>
         <img
           class="md:hidden mx-auto absolute right-0 left-0 rounded bg-surface p-3 h-fit md:relative"
-          src="https://arweave.net/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
+          src="https://turbo-gateway.com/AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"
           alt="logo"
           width="50px"
           height="50px"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "dependencies": {
     "@ant-design/icons": "5.4.0",
     "@ar.io/sdk": "^3.22.1",
-    "@ar.io/wayfinder-core": "^1.9.0",
-    "@ar.io/wayfinder-react": "^1.0.27",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/cards/ARNSCard/ARNSCard.tsx
+++ b/src/components/cards/ARNSCard/ARNSCard.tsx
@@ -1,27 +1,17 @@
-import { useWayfinderUrl } from '@ar.io/wayfinder-react';
-import { useGlobalState } from '@src/state';
-import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ARNSMapping } from '../../../types';
+import { NETWORK_DEFAULTS } from '../../../utils/constants';
 import './styles.css';
 
 function ARNSCard({
   domain,
   imageUrl,
 }: Omit<ARNSMapping, 'processId'> & { imageUrl: string }) {
-  const [{ gateway }] = useGlobalState();
-  const params = useMemo(() => ({ arnsName: domain }), [domain]);
-  const { resolvedUrl, error } = useWayfinderUrl(params);
-
-  if (error) {
-    console.error(error);
-  }
-
   return (
     <Link
       target="_blank"
-      to={resolvedUrl?.toString() ?? `https://${domain}.${gateway}`}
+      to={`https://${domain}.${NETWORK_DEFAULTS.ARNS.HOST}`}
       className="arns-card hover"
       rel="noreferrer"
     >

--- a/src/components/cards/ARNSCard/ARNSCard.tsx
+++ b/src/components/cards/ARNSCard/ARNSCard.tsx
@@ -1,17 +1,33 @@
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ARNSMapping } from '../../../types';
 import { NETWORK_DEFAULTS } from '../../../utils/constants';
 import './styles.css';
 
+function getBaseGateway(): string {
+  const hostname = window.location.hostname;
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return NETWORK_DEFAULTS.ARNS.HOST;
+  }
+  // strip the first subdomain (e.g. "arns.ar.io" -> "ar.io")
+  const parts = hostname.split('.');
+  if (parts.length > 2) {
+    return parts.slice(1).join('.');
+  }
+  return hostname;
+}
+
 function ARNSCard({
   domain,
   imageUrl,
 }: Omit<ARNSMapping, 'processId'> & { imageUrl: string }) {
+  const baseGateway = useMemo(() => getBaseGateway(), []);
+
   return (
     <Link
       target="_blank"
-      to={`https://${domain}.${NETWORK_DEFAULTS.ARNS.HOST}`}
+      to={`https://${domain}.${baseGateway}`}
       className="arns-card hover"
       rel="noreferrer"
     >

--- a/src/components/layout/ExtendLease/ExtendLease.tsx
+++ b/src/components/layout/ExtendLease/ExtendLease.tsx
@@ -334,7 +334,8 @@ function ExtendLease() {
           backText="Cancel"
           nextText="Continue"
           nextButtonTooltip={
-            ARNS_PURCHASES_DISABLED
+            ARNS_PURCHASES_DISABLED &&
+            registrationType === TRANSACTION_TYPES.BUY
               ? ARNS_PURCHASES_DISABLED_TOOLTIP
               : undefined
           }
@@ -352,7 +353,10 @@ function ExtendLease() {
             navigate(`/manage/names/${lowerCaseDomain(name!)}`);
           }}
           onNext={
-            ARNS_PURCHASES_DISABLED || !arioFee || arioFee <= 0
+            (ARNS_PURCHASES_DISABLED &&
+              registrationType === TRANSACTION_TYPES.BUY) ||
+            !arioFee ||
+            arioFee <= 0
               ? undefined
               : () => {
                   if (

--- a/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
+++ b/src/components/layout/UpgradeUndernames/UpgradeUndernames.tsx
@@ -17,10 +17,6 @@ import {
   formatARIOWithCommas,
   lowerCaseDomain,
 } from '../../../utils';
-import {
-  ARNS_PURCHASES_DISABLED,
-  ARNS_PURCHASES_DISABLED_TOOLTIP,
-} from '../../../utils/constants';
 import Counter from '../../inputs/Counter/Counter';
 import WorkflowButtons from '../../inputs/buttons/WorkflowButtons/WorkflowButtons';
 import Loader from '../Loader/Loader';
@@ -141,14 +137,10 @@ function UpgradeUndernames() {
         <WorkflowButtons
           backText="Cancel"
           nextText="Confirm"
-          nextButtonTooltip={
-            ARNS_PURCHASES_DISABLED
-              ? ARNS_PURCHASES_DISABLED_TOOLTIP
-              : undefined
-          }
+          nextButtonTooltip={undefined}
           onBack={() => navigate(`/manage/names/${lowerCaseDomain(name)}`)}
           onNext={
-            ARNS_PURCHASES_DISABLED || !arioFee || arioFee < 0
+            !arioFee || arioFee < 0
               ? undefined
               : () => {
                   const increaseUndernamePayload: IncreaseUndernamesPayload = {

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -640,8 +640,11 @@ function Checkout() {
               Back
             </button>
             {(() => {
+              const isNewPurchase =
+                workflowName === ARNS_INTERACTION_TYPES.BUY_RECORD ||
+                workflowName === ARNS_INTERACTION_TYPES.UPGRADE_NAME;
               const payDisabled =
-                ARNS_PURCHASES_DISABLED ||
+                (ARNS_PURCHASES_DISABLED && isNewPurchase) ||
                 isInsufficientBalance ||
                 isLoadingCostDetail ||
                 isLoadingIntentPrice ||
@@ -663,7 +666,9 @@ function Checkout() {
                         : 'Pay now'}
                 </button>
               );
-              return ARNS_PURCHASES_DISABLED && !isProcessingBaseToken ? (
+              return ARNS_PURCHASES_DISABLED &&
+                isNewPurchase &&
+                !isProcessingBaseToken ? (
                 <AntdTooltip
                   title={ARNS_PURCHASES_DISABLED_TOOLTIP}
                   color="var(--box-color)"

--- a/src/state/contexts/GlobalState.tsx
+++ b/src/state/contexts/GlobalState.tsx
@@ -31,7 +31,6 @@ import {
   APP_VERSION,
   ARIO_AO_CU_URL,
   ARIO_PROCESS_ID,
-  ARWEAVE_HOST,
   DEFAULT_ARWEAVE,
   NETWORK_DEFAULTS,
 } from '../../utils/constants';
@@ -58,7 +57,7 @@ function loadSettingsFromStorage(): {
       );
 
       return {
-        gateway: settings.network?.gateway || ARWEAVE_HOST,
+        gateway: settings.network?.gateway || NETWORK_DEFAULTS.ARNS.HOST,
         aoNetwork: settings.network?.aoNetwork || NETWORK_DEFAULTS.AO,
         turboNetwork: settings.network?.turboNetwork || NETWORK_DEFAULTS.TURBO,
         arioProcessId: settings.arns?.arioProcessId || ARIO_PROCESS_ID,
@@ -78,7 +77,7 @@ export const defaultArweave = new SimpleArweaveDataProvider(DEFAULT_ARWEAVE);
 
 // Load saved settings or use defaults
 const savedSettings = loadSettingsFromStorage();
-const initialGateway = savedSettings?.gateway || ARWEAVE_HOST;
+const initialGateway = savedSettings?.gateway || NETWORK_DEFAULTS.ARNS.HOST;
 const initialAoNetwork = savedSettings?.aoNetwork || NETWORK_DEFAULTS.AO;
 const initialTurboNetwork =
   savedSettings?.turboNetwork || NETWORK_DEFAULTS.TURBO;

--- a/src/state/contexts/GlobalState.tsx
+++ b/src/state/contexts/GlobalState.tsx
@@ -6,14 +6,6 @@ import {
   AoARIOWrite,
   AoClient,
 } from '@ar.io/sdk/web';
-import {
-  CompositeGatewaysProvider,
-  LocalStorageGatewaysProvider,
-  NetworkGatewaysProvider,
-  RandomRoutingStrategy,
-  StaticGatewaysProvider,
-} from '@ar.io/wayfinder-core';
-import { WayfinderProvider } from '@ar.io/wayfinder-react';
 import { connect } from '@permaweb/aoconnect';
 import { SETTINGS_STORAGE_KEY } from '@src/hooks';
 import eventEmitter from '@src/utils/events';
@@ -28,7 +20,6 @@ import React, {
 import { ArweaveCompositeDataProvider } from '../../services/arweave/ArweaveCompositeDataProvider';
 import { SimpleArweaveDataProvider } from '../../services/arweave/SimpleArweaveDataProvider';
 import {
-  APP_VERSION,
   ARIO_AO_CU_URL,
   ARIO_PROCESS_ID,
   DEFAULT_ARWEAVE,
@@ -185,34 +176,7 @@ export function GlobalStateProvider({
 
   return (
     <GlobalStateContext.Provider value={[state, dispatchGlobalState]}>
-      <WayfinderProvider
-        routingSettings={{
-          strategy: new RandomRoutingStrategy({
-            gatewaysProvider: new CompositeGatewaysProvider({
-              providers: [
-                // cache the network list
-                new LocalStorageGatewaysProvider({
-                  gatewaysProvider: new NetworkGatewaysProvider({
-                    ario: state.arioContract,
-                  }),
-                }),
-                // fallback to user-defined static gateway
-                new StaticGatewaysProvider({
-                  gateways: ['https://' + state.gateway],
-                }),
-              ],
-            }),
-          }),
-        }}
-        telemetrySettings={{
-          enabled: true,
-          clientName: 'arns-app',
-          clientVersion: APP_VERSION,
-          sampleRate: 1,
-        }}
-      >
-        {children}
-      </WayfinderProvider>
+      {children}
     </GlobalStateContext.Provider>
   );
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -50,7 +50,7 @@ export const ARWEAVE_GRAPHQL_URL =
 export const HYPERBEAM_URL = import.meta.env.VITE_HYPERBEAM_URL;
 export const WALLETCONNECT_PROJECT_ID = '692e2917daed8533f0f59cd604c3751a';
 export const DEFAULT_ARWEAVE = new Arweave({
-  host: ARWEAVE_HOST,
+  host: 'turbo-gateway.com',
   protocol: 'https',
   port: 443,
 });
@@ -168,7 +168,7 @@ export const NETWORK_DEFAULTS = {
   TURBO: {
     UPLOAD_URL: 'https://turbo.ardrive.io',
     PAYMENT_URL: `https://${PAYMENT_SERVICE_FQDN}`,
-    GATEWAY_URL: 'https://arweave.net',
+    GATEWAY_URL: 'https://turbo-gateway.com',
     WALLETS_URL: `https://${PAYMENT_SERVICE_FQDN}/info`,
     STRIPE_PUBLISHABLE_KEY,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,33 +129,6 @@
     eventemitter3 "^5.0.1"
     prompts "^2.4.2"
 
-"@ar.io/wayfinder-core@1.9.0", "@ar.io/wayfinder-core@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/wayfinder-core/-/wayfinder-core-1.9.0.tgz#adc30661542f5835974a47cf010c7bd5dbdfecd5"
-  integrity sha512-PFREB3xOSA/WBQyVGiFnUifBmRW1kOgKfePC9kPC69vPrrXLeZ92WMzjbX8xPYxMNSLxDL/+GYdjSh7dBbyrVg==
-  dependencies:
-    "@dha-team/arbundles" "^1.0.3"
-    "@opentelemetry/api" "^1.9.0"
-    "@opentelemetry/context-zone" "^2.0.1"
-    "@opentelemetry/exporter-trace-otlp-http" "^0.206.0"
-    "@opentelemetry/sdk-trace-base" "^2.0.1"
-    "@opentelemetry/sdk-trace-node" "^2.0.1"
-    "@opentelemetry/sdk-trace-web" "^2.0.1"
-    arweave "^1.14.0"
-    eventemitter3 "^5.0.1"
-    plimit-lit "^3.0.1"
-    rfc4648 "^1.5.4"
-    zone.js "^0.15.1"
-
-"@ar.io/wayfinder-react@^1.0.27":
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/@ar.io/wayfinder-react/-/wayfinder-react-1.0.27.tgz#be22f8c60909a77825f1fe9a2f6d72df6c68a9b7"
-  integrity sha512-2HlDOcePLMwVmZlWfsSVsf6yFCiUGOJa760VkYR80zQWfnPs6LqVkcIhwCacOSvpwiuWAiihznGJaVrdE+J9oQ==
-  dependencies:
-    "@ar.io/wayfinder-core" "1.9.0"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-
 "@ardrive/turbo-sdk@1.39.2":
   version "1.39.2"
   resolved "https://registry.yarnpkg.com/@ardrive/turbo-sdk/-/turbo-sdk-1.39.2.tgz#6be800b76a77742f2e20547e3506dbe45e1310d8"
@@ -1808,7 +1781,7 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@dha-team/arbundles@1.0.3", "@dha-team/arbundles@^1.0.3":
+"@dha-team/arbundles@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@dha-team/arbundles/-/arbundles-1.0.3.tgz#4080514945a830e7d61f3d079401f28e8bd198d2"
   integrity sha512-/XelOo5V/1o1M8VchCQ+F7N5kxwirWh5jD5zg1KECaV80Qld6aKBSgG19VLlBsRUXbRUfjM+LDRPJm9Hjfmycg==
@@ -3120,155 +3093,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@opentelemetry/api-logs@0.206.0":
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.206.0.tgz#4df1526fed55fe686e69100cbeea0311fa04565d"
-  integrity sha512-yIVDu9jX//nV5wSMLZLdHdb1SKHIMj9k+wQVFtln5Flcgdldz9BkHtavvExQiJqBZg2OpEEJEZmzQazYztdz2A==
-  dependencies:
-    "@opentelemetry/api" "^1.3.0"
-
-"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
-  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
-
-"@opentelemetry/context-async-hooks@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz#4416bc2df780c1dda1129afb9392d55831dd861d"
-  integrity sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==
-
-"@opentelemetry/context-zone-peer-dep@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.0.1.tgz#5b8e19fbc5a4676d11332fc9466baaafdfffa3c3"
-  integrity sha512-jgN4jGULoJo46HiJx60E8XR8tJEpuY9stQ7KJ936AfEB1vf6YCbgR/a5bC95frLAnbSbYbaP5ti2jCFxormK4A==
-
-"@opentelemetry/context-zone@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-zone/-/context-zone-2.0.1.tgz#2007423d7038156ab0fbe3637c6786b0d6f9134e"
-  integrity sha512-xJmgpCBNZR0fS5ExbRl8Qn+Xg6k8BuRUR4BAjYeGzCuZ9DCYarZ05kEJCdG9hqrt0GcBtCfSTnr2ceeCWhoy5A==
-  dependencies:
-    "@opentelemetry/context-zone-peer-dep" "2.0.1"
-    zone.js "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0"
-
-"@opentelemetry/core@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.0.1.tgz#44e1149d5666a4743cde943ef89841db3ce0f8bc"
-  integrity sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==
-  dependencies:
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/core@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.1.0.tgz#5539f04eb9e5245e000b0c3f77bdfaa07557e3a7"
-  integrity sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==
-  dependencies:
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/exporter-trace-otlp-http@^0.206.0":
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.206.0.tgz#a9215ae233d0df7a15039bec9fd67ec6da1d28ed"
-  integrity sha512-xiEhJZxE9yDb13FVW4XaF7J56boLv1NALOGEVu3F8jMC24iZmX5TSVRJCNGLWyy1Xb3N27Yu31kdSsmEBCnxyw==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/otlp-exporter-base" "0.206.0"
-    "@opentelemetry/otlp-transformer" "0.206.0"
-    "@opentelemetry/resources" "2.1.0"
-    "@opentelemetry/sdk-trace-base" "2.1.0"
-
-"@opentelemetry/otlp-exporter-base@0.206.0":
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.206.0.tgz#9090e04ab5cb235074fc0fbeace7c6ef7305e492"
-  integrity sha512-Rv54oSNKMHYS5hv+H5EGksfBUtvPQWFTK+Dk6MjJun9tOijCsFJrhRFvAqg5d67TWSMn+ZQYRKIeXh5oLVrpAQ==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/otlp-transformer" "0.206.0"
-
-"@opentelemetry/otlp-transformer@0.206.0":
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.206.0.tgz#c5279f00c8ab3069226cc084a062bd1c684841fd"
-  integrity sha512-Li2Cik1WnmNbU2mmTnw7DxvRiXhMcnAuTfAclP8y/zy7h5+GrLDpTZ+Z0XUs+Q3MLkb/h3ry4uFrC/z+2a6X7g==
-  dependencies:
-    "@opentelemetry/api-logs" "0.206.0"
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-    "@opentelemetry/sdk-logs" "0.206.0"
-    "@opentelemetry/sdk-metrics" "2.1.0"
-    "@opentelemetry/sdk-trace-base" "2.1.0"
-    protobufjs "^7.3.0"
-
-"@opentelemetry/resources@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.0.1.tgz#0365d134291c0ed18d96444a1e21d0e6a481c840"
-  integrity sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/resources@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.1.0.tgz#11772e732af4f27953cf55567a6630d8b4d8282d"
-  integrity sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/sdk-logs@0.206.0":
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.206.0.tgz#ac5251651bc80b80ffd8c4b1b028aa98f7b4c738"
-  integrity sha512-SQ2yTmqe4Mw9RI3a/glVkfjWPsXh6LySvnljXubiZq4zu+UP8NMJt2j82ZsYb+KpD7Eu+/41/7qlJnjdeVjz7Q==
-  dependencies:
-    "@opentelemetry/api-logs" "0.206.0"
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-
-"@opentelemetry/sdk-metrics@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz#fbb9b270ee56c29feba885062e5c0418213fccf2"
-  integrity sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-
-"@opentelemetry/sdk-trace-base@2.0.1", "@opentelemetry/sdk-trace-base@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz#25808bb6a3d08a501ad840249e4d43d3493eb6e5"
-  integrity sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/resources" "2.0.1"
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/sdk-trace-base@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz#9d31474824e9ed215f94bf71260d5321f64d402a"
-  integrity sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-    "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/sdk-trace-node@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.1.tgz#bbb9bdb4985d7930941b3d4023e1661ba46f60c1"
-  integrity sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==
-  dependencies:
-    "@opentelemetry/context-async-hooks" "2.0.1"
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/sdk-trace-base" "2.0.1"
-
-"@opentelemetry/sdk-trace-web@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz#ad6f590cbc1a1a2e800a3815bd6b1923c8c78a4d"
-  integrity sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/sdk-trace-base" "2.0.1"
-
-"@opentelemetry/semantic-conventions@^1.29.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz#149449bd4df4d0464220915ad4164121e0d75d4d"
-  integrity sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==
-
 "@parcel/watcher-android-arm64@2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz#c2c19a3c442313ff007d2d7a9c2c1dd3e1c9ca84"
@@ -3457,59 +3281,6 @@
   integrity sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==
   dependencies:
     playwright "1.48.1"
-
-"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
-  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
-
-"@protobufjs/base64@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
-  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
-
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
-
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
-
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
-
-"@protobufjs/float@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
-  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
-
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
-  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
-
-"@protobufjs/path@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
-  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
-
-"@protobufjs/pool@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
-  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
-
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
-  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@radix-ui/number@1.1.0":
   version "1.1.0"
@@ -6492,13 +6263,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
   integrity sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==
 
-"@types/node@>=13.7.0":
-  version "22.13.11"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz#f0ed6b302dcf0f4229d44ea707e77484ad46d234"
-  integrity sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==
-  dependencies:
-    undici-types "~6.20.0"
-
 "@types/node@^12.12.54":
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
@@ -7536,7 +7300,7 @@ arweave@^1.10.13, arweave@^1.13.7, arweave@^1.15.1:
     base64-js "^1.5.1"
     bignumber.js "^9.0.2"
 
-arweave@^1.14.0, arweave@^1.15.7:
+arweave@^1.15.7:
   version "1.15.7"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.15.7.tgz#d09265d128e93a471203649de083ba7fec52cb29"
   integrity sha512-F+Y4iWU1qea9IsKQ/YNmLsY4DHQVsaJBuhEbFxQn9cfGHOmtXE+bwo14oY8xqymsqSNf/e1PeIfLk7G7qN/hVA==
@@ -11845,11 +11609,6 @@ logform@^2.7.0:
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
 
-long@^5.0.0:
-  version "5.3.1"
-  resolved "https://registry.npmjs.org/long/-/long-5.3.1.tgz#9d4222d3213f38a5ec809674834e0f0ab21abe96"
-  integrity sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==
-
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -13242,24 +13001,6 @@ property-information@^5.3.0:
   dependencies:
     xtend "^4.0.0"
 
-protobufjs@^7.3.0:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.3.tgz#13f95a9e3c84669995ec3652db2ac2fb00b89363"
-  integrity sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
 proxy-compare@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.6.0.tgz#5e8c8b5c3af7e7f17e839bf6cf1435bcc4d315b0"
@@ -14304,11 +14045,6 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rfc4648@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.4.tgz#1174c0afba72423a0b70c386ecfeb80aa61b05ca"
-  integrity sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==
-
 rfdc@^1.3.0, rfdc@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
@@ -15349,11 +15085,6 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici-types@~6.20.0:
-  version "6.20.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
-  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
-
 undici@^5.19.1:
   version "5.28.4"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
@@ -16290,11 +16021,6 @@ zod@^4.1.5:
   version "4.1.13"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.13.tgz#93699a8afe937ba96badbb0ce8be6033c0a4b6b1"
   integrity sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==
-
-"zone.js@^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0", zone.js@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.15.1.tgz#1e109adb75f80e9e004ee8e0d4a0a52e0a336481"
-  integrity sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==
 
 zustand@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- **Gateway URL routing**: Separated URLs by purpose — GraphQL stays on `arweave.net`, transaction/data fetching moves to `turbo-gateway.com`, ArNS name links use `ar.io`
- **Purchase disable scope**: `ARNS_PURCHASES_DISABLED` now only blocks flows that create new ANTs (`BUY_RECORD`, `UPGRADE_NAME`). Lease extensions and undername upgrades proceed normally during the migration
- Version bump to 1.30.1

## Test plan
- [ ] Verify lease extension flow works end-to-end with `ARNS_PURCHASES_DISABLED = true`
- [ ] Verify undername upgrade flow works end-to-end with flag enabled
- [ ] Verify new name registration is still blocked (HomeSearch, Register, Checkout)
- [ ] Verify upgrade-to-permabuy on ExtendLease page is still blocked
- [ ] Verify GraphQL queries resolve correctly via `arweave.net`
- [ ] Verify transaction data loads via `turbo-gateway.com`
- [ ] Verify ArNS domain links route through `ar.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)