### PR TITLE
feat(banner): Solana migration announcement banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 
 ### Changed
 
-- Updated top banner to announce Solana migration with May 15, 2026 snapshot date and "Learn More" link
+- Updated top banner to announce Solana migration with May 15, 2026 snapshot date, registration call-to-action, and "Learn More" link
 - Updated purchase-disabled tooltip to reference Solana migration
 - Banner now displays on all pages (except settings)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.30.2] - 2026-04-27
+
+### Changed
+
+- Updated top banner to announce Solana migration with May 15, 2026 snapshot date and "Learn More" link
+- Updated purchase-disabled tooltip to reference Solana migration
+- Banner now displays on all pages (except settings)
+
 ## [1.30.1] - 2026-04-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ TypeScript, and TailwindCSS.
 ```bash
 yarn                  # Install dependencies
 yarn dev              # Start development server (sets NODE_ENV=prod, VITE_GITHUB_HASH=local)
-yarn build            # Build for production (includes TypeScript compilation and Vite build with increased memory)
+yarn build            # Build for production (Vite build with increased memory)
+yarn build:production # Build with VITE_ENVIRONMENT=production
+yarn build:develop    # Build with VITE_ENVIRONMENT=develop
 yarn preview          # Preview production build
 ```
 
@@ -114,9 +116,24 @@ The app integrates with the AO (Arweave Operating System) ecosystem:
 Hash-based routing using React Router v6 (`createHashRouter`):
 
 - Routes defined in `src/App.tsx` with lazy loading for pages
-- Main routes: `/`, `/register`, `/manage`, `/manage/:domain`,
-  `/undernames/:domain`, `/ant/:antId`, `/prices`, `/settings/*`
 - Sentry integration via `wrapCreateBrowserRouter`
+- Main routes:
+  - `/` — Home/search
+  - `/connect` — Wallet connection modal
+  - `/register/:name` — Name registration
+  - `/checkout` — Payment checkout
+  - `/manage` — Redirects to `/manage/names`
+  - `/manage/:path` — Asset management (names or ants tab)
+  - `/manage/ants/:id` — Manage specific ANT
+  - `/manage/ants/:id/undernames` — ANT undernames
+  - `/manage/names/:name` — Manage specific domain
+  - `/manage/names/:name/extend` — Extend lease
+  - `/manage/names/:name/upgrade-undernames` — Increase undernames
+  - `/manage/names/:name/undernames` — Domain undernames
+  - `/transaction/review`, `/transaction/complete` — Transaction flow
+  - `/returned-names` — Returned Names Protocol page
+  - `/prices` — Pricing info
+  - `/settings/network`, `/settings/devtools` — Settings (separate layout)
 
 ### Wallet Integration
 
@@ -167,6 +184,13 @@ wallet type
 - **Radix UI** for headless components (checkbox, radio, select, switch)
 - **Framer Motion** for animations
 - CSS modules pattern: component folders contain `styles.css`
+
+### Linting (Biome)
+
+- Single quotes for JavaScript/TypeScript (`quoteStyle: "single"`)
+- Import organization enabled (auto-sorted on format)
+- `noExplicitAny` and `noEmptyBlockStatements` are turned off
+- `noUnusedVariables` is an error — clean up unused imports/vars
 
 ## File Organization Rules
 
@@ -235,6 +259,8 @@ Use `NotificationOnlyError` for expected/user-facing errors. Use standard
 - Defined in Vite config, not exposed via process.env for security
 - Key variables: `VITE_ARWEAVE_HOST`, `VITE_ARWEAVE_GRAPHQL_URL`,
   `VITE_HYPERBEAM_URL`, `VITE_SENTRY_*`, `VITE_ARNS_NAME`
+- Build-time variables: `VITE_ENVIRONMENT` (production/develop),
+  `VITE_NODE_ENV`, `VITE_GITHUB_HASH` (set to `local` in dev)
 
 ### Arweave Deployment
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.30.1",
+  "version": "1.30.2",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -12,10 +12,8 @@ function Layout() {
   const location = useLocation();
   const [{ percentLoaded }] = useArNSState();
 
-  const homeOrRegister =
-    location.pathname === '/' || location.pathname.startsWith('/register');
-  // TODO: Remove banner once Hyperbeam migration is complete and purchases are re-enabled
-  const showBanner = homeOrRegister;
+  // TODO: Remove banner once Solana migration is complete and purchases are re-enabled
+  const showBanner = location.pathname !== '/settings';
 
   return (
     <div

--- a/src/components/layout/Layout/TopBanner.tsx
+++ b/src/components/layout/Layout/TopBanner.tsx
@@ -1,5 +1,5 @@
 import { useIsMobile } from '@src/hooks';
-import { ARIO_DISCORD_LINK } from '@src/utils/constants';
+import { SOLANA_MIGRATION_LINK } from '@src/utils/constants';
 import { Link } from 'react-router-dom';
 
 const TopBanner = () => {
@@ -15,11 +15,11 @@ const TopBanner = () => {
         fontSize: '14px',
       }}
     >
-      ArNS name purchases and upgrades are temporarily unavailable during the
-      migration to Hyperbeam (AO Mainnet). Existing names can still be modified.
-      Follow updates in{' '}
+      <strong>AR.IO is migrating to Solana!</strong> ArNS name purchases are
+      paused and will resume after launch. All names will be snapshotted May 15,
+      2026.{' '}
       <Link
-        to={ARIO_DISCORD_LINK}
+        to={SOLANA_MIGRATION_LINK}
         target="_blank"
         rel="noreferrer"
         className="link hover"
@@ -30,9 +30,8 @@ const TopBanner = () => {
           fontWeight: 600,
         }}
       >
-        Discord
+        Learn More &rarr;
       </Link>
-      .
     </div>
   );
 };

--- a/src/components/layout/Layout/TopBanner.tsx
+++ b/src/components/layout/Layout/TopBanner.tsx
@@ -15,9 +15,8 @@ const TopBanner = () => {
         fontSize: '14px',
       }}
     >
-      <strong>AR.IO is migrating to Solana!</strong> ArNS name purchases are
-      paused and will resume after launch. All names will be snapshotted May 15,
-      2026.{' '}
+      <strong>Ar.io is migrating to Solana!</strong> Purchases are paused and
+      will resume shortly. Register before the May 15, 2026 snapshot!{' '}
       <Link
         to={SOLANA_MIGRATION_LINK}
         target="_blank"

--- a/src/components/layout/Layout/TopBanner.tsx
+++ b/src/components/layout/Layout/TopBanner.tsx
@@ -1,5 +1,6 @@
 import { useIsMobile } from '@src/hooks';
 import { SOLANA_MIGRATION_LINK } from '@src/utils/constants';
+import { ExternalLinkIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const TopBanner = () => {
@@ -29,7 +30,11 @@ const TopBanner = () => {
           fontWeight: 600,
         }}
       >
-        Learn More &rarr;
+        Learn More{' '}
+        <ExternalLinkIcon
+          size={14}
+          style={{ display: 'inline', verticalAlign: 'middle' }}
+        />
       </Link>
     </div>
   );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,7 +25,8 @@ export const APP_VERSION = __NPM_PACKAGE_VERSION__ || '1.0.0';
 /** When true, all ArNS name purchase flows (buy, extend, upgrade undernames) are disabled. */
 export const ARNS_PURCHASES_DISABLED = true;
 export const ARNS_PURCHASES_DISABLED_TOOLTIP =
-  'ArNS registrations are temporarily disabled while the ar.io registry migrates to HyperBEAM. Existing names continue to function normally.';
+  'ArNS name purchases are paused during the migration to Solana and will resume after launch.';
+export const SOLANA_MIGRATION_LINK = 'https://ar.io/solana-migration/';
 
 // This is the minimum version all workflows are currently compatible with (including reassign, release, etc)
 export const MIN_ANT_VERSION = 16;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,7 +25,7 @@ export const APP_VERSION = __NPM_PACKAGE_VERSION__ || '1.0.0';
 /** When true, all ArNS name purchase flows (buy, extend, upgrade undernames) are disabled. */
 export const ARNS_PURCHASES_DISABLED = true;
 export const ARNS_PURCHASES_DISABLED_TOOLTIP =
-  'ArNS name purchases are paused during the migration to Solana and will resume after launch.';
+  'Purchases are paused during the migration to Solana and will resume shortly.';
 export const SOLANA_MIGRATION_LINK = 'https://ar.io/solana-migration/';
 
 // This is the minimum version all workflows are currently compatible with (including reassign, release, etc)


### PR DESCRIPTION
## Summary
- Replace Hyperbeam migration banner with Solana migration announcement: **"Ar.io is migrating to Solana! Purchases are paused and will resume shortly. Register before the May 15, 2026 snapshot!"** with a "Learn More" link to https://ar.io/solana-migration/
- Update purchase-disabled tooltip to reference Solana migration
- Show banner on all pages (except settings)
- Bump version to 1.30.2

## Test plan
- [ ] Verify banner displays on home, manage, register, and other pages
- [ ] Verify banner does not display on settings pages
- [ ] Verify "Learn More" link opens https://ar.io/solana-migration/ in new tab
- [ ] Verify disabled purchase buttons show updated Solana tooltip
- [ ] Check banner layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)