### PR TITLE
fix(links): use ar.io for all ArNS name links, update snapshot date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.30.3] - 2026-05-06
+
+### Changed
+
+- Updated top banner snapshot date to June 1, 2026
+- Fixed ArNS name links in DomainsTable, UndernamesTable, ReturnedNamesTable, and HomeSearch to always use ar.io instead of the configurable data gateway (which could resolve to arweave.net)
+
 ## [1.30.2] - 2026-04-27
 
 ### Changed
 
-- Updated top banner to announce Solana migration with May 15, 2026 snapshot date, registration call-to-action, and "Learn More" link
+- Updated top banner to announce Solana migration with snapshot date, registration call-to-action, and "Learn More" link
 - Updated purchase-disabled tooltip to reference Solana migration
 - Banner now displays on all pages (except settings)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "1.30.2",
+  "version": "1.30.3",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/data-display/tables/DomainsTable.tsx
+++ b/src/components/data-display/tables/DomainsTable.tsx
@@ -36,6 +36,7 @@ import {
 import {
   ARNS_DOCS_LINK,
   MIN_ANT_VERSION,
+  NETWORK_DEFAULTS,
   PERMANENT_DOMAIN_MESSAGE,
 } from '@src/utils/constants';
 import { ANTStateError } from '@src/utils/errors';
@@ -119,9 +120,8 @@ const DomainsTable = ({
 }) => {
   const navigate = useNavigate();
   const [{ walletAddress }] = useWalletState();
-  const [
-    { arioProcessId, aoNetwork, hyperbeamUrl, antRegistryProcessId, gateway },
-  ] = useGlobalState();
+  const [{ arioProcessId, aoNetwork, hyperbeamUrl, antRegistryProcessId }] =
+    useGlobalState();
   const [{ loading: loadingArnsState }, dispatchArNSState] = useArNSState();
   const [, dispatchModalState] = useModalState();
   const [, dispatchTransactionState] = useTransactionState();
@@ -296,7 +296,7 @@ const DomainsTable = ({
                     className="link gap-2 w-fit whitespace-nowrap items-center"
                     to={`https://${encodeDomainToASCII(
                       row.getValue('name'),
-                    )}.${gateway}`}
+                    )}.${NETWORK_DEFAULTS.ARNS.HOST}`}
                     target="_blank"
                   >
                     {formatForMaxCharCount(decodeDomainToASCII(rowValue), 20)}{' '}

--- a/src/components/data-display/tables/ReturnedNamesTable.tsx
+++ b/src/components/data-display/tables/ReturnedNamesTable.tsx
@@ -22,6 +22,7 @@ import {
 import {
   ARNS_PURCHASES_DISABLED,
   ARNS_PURCHASES_DISABLED_TOOLTIP,
+  NETWORK_DEFAULTS,
   START_RNP_PREMIUM,
 } from '@src/utils/constants';
 import { useQueryClient } from '@tanstack/react-query';
@@ -95,8 +96,7 @@ const ReturnedNamesTable = ({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
-  const [{ arioProcessId, arioTicker, arioContract, gateway }] =
-    useGlobalState();
+  const [{ arioProcessId, arioTicker, arioContract }] = useGlobalState();
   const [{ walletAddress }] = useWalletState();
 
   const [tableData, setTableData] = useState<Array<TableData>>([]);
@@ -302,7 +302,7 @@ const ReturnedNamesTable = ({
                     className="link gap-2 w-fit items-center"
                     to={`https://${encodeDomainToASCII(
                       row.getValue('name'),
-                    )}.${gateway}`}
+                    )}.${NETWORK_DEFAULTS.ARNS.HOST}`}
                     target="_blank"
                   >
                     {formatForMaxCharCount(decodeDomainToASCII(rowValue), 20)}{' '}

--- a/src/components/data-display/tables/UndernamesTable.tsx
+++ b/src/components/data-display/tables/UndernamesTable.tsx
@@ -31,7 +31,7 @@ import {
   encodePrimaryName,
   formatForMaxCharCount,
 } from '@src/utils';
-import { MIN_ANT_VERSION } from '@src/utils/constants';
+import { MIN_ANT_VERSION, NETWORK_DEFAULTS } from '@src/utils/constants';
 import eventEmitter from '@src/utils/events';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { Plus, Star } from 'lucide-react';
@@ -67,9 +67,8 @@ const UndernamesTable = ({
   state?: AoANTState | null;
   isLoading: boolean;
 }) => {
-  const [
-    { arioProcessId, antAoClient, hyperbeamUrl, antRegistryProcessId, gateway },
-  ] = useGlobalState();
+  const [{ arioProcessId, antAoClient, hyperbeamUrl, antRegistryProcessId }] =
+    useGlobalState();
   const [, dispatchArNSState] = useArNSState();
 
   const [{ wallet, walletAddress }] = useWalletState();
@@ -324,7 +323,7 @@ const UndernamesTable = ({
                     className="link gap-2 items-center w-fit"
                     to={`https://${
                       rowValue === '@' ? '' : `${rowValue}_`
-                    }${encodeDomainToASCII(arnsRecord.name)}.${gateway}`}
+                    }${encodeDomainToASCII(arnsRecord.name)}.${NETWORK_DEFAULTS.ARNS.HOST}`}
                     target="_blank"
                   >
                     {formatForMaxCharCount(decodeDomainToASCII(rowValue), 30)}{' '}

--- a/src/components/inputs/Search/HomeSearch.tsx
+++ b/src/components/inputs/Search/HomeSearch.tsx
@@ -5,11 +5,11 @@ import { Tooltip } from '@src/components/data-display';
 import { ArioSpinner } from '@src/components/data-display/Spinner';
 import { RNPChart } from '@src/components/data-display/charts/RNPChart';
 import { CircleCheckFilled, SearchIcon } from '@src/components/icons';
-import { useGlobalState } from '@src/state';
 import { decodeDomainToASCII, lowerCaseDomain } from '@src/utils';
 import {
   ARNS_PURCHASES_DISABLED,
   ARNS_PURCHASES_DISABLED_TOOLTIP,
+  NETWORK_DEFAULTS,
 } from '@src/utils/constants';
 import { Tooltip as AntdTooltip } from 'antd';
 import { ChevronRight, CircleAlert, XIcon } from 'lucide-react';
@@ -46,7 +46,6 @@ function HomeSearch() {
   const [domainRecord, setDomainRecord] = useState<AoArNSNameData>();
   const [showResults, setShowResults] = useState(true);
   const [isReturnedName, setIsReturnedName] = useState(false);
-  const [{ gateway }] = useGlobalState();
 
   useEffect(() => {
     validateDomain(domainQuery);
@@ -359,7 +358,8 @@ function HomeSearch() {
                 ) : (
                   <div className="flex flex-row w-full justify-between mt-4">
                     <span className="text-xl text-grey">
-                      {decodeDomainToASCII(domainQuery)}.{gateway}
+                      {decodeDomainToASCII(domainQuery)}.
+                      {NETWORK_DEFAULTS.ARNS.HOST}
                     </span>
                     <button
                       className="text-[12px] text-white whitespace-nowrap flex items-center"

--- a/src/components/layout/Layout/TopBanner.tsx
+++ b/src/components/layout/Layout/TopBanner.tsx
@@ -17,7 +17,7 @@ const TopBanner = () => {
       }}
     >
       <strong>Ar.io is migrating to Solana!</strong> Purchases are paused and
-      will resume shortly. Register before the May 15, 2026 snapshot!{' '}
+      will resume shortly. Register before the June 1, 2026 snapshot!{' '}
       <Link
         to={SOLANA_MIGRATION_LINK}
         target="_blank"


### PR DESCRIPTION
## Summary
- **Fixed ArNS name links** showing `arweave.net` instead of `ar.io`. The `gateway` state variable is the Arweave L1 data gateway (`arweave.net`) but was incorrectly used to build user-facing ArNS domain links in DomainsTable, UndernamesTable, ReturnedNamesTable, and HomeSearch. Now uses `NETWORK_DEFAULTS.ARNS.HOST` (`ar.io`) for all clickable name links.
- **Updated banner snapshot date** from May 15 to June 1, 2026
- Bumped version to 1.30.3

## Test plan
- [ ] Click a name in Manage Assets → opens as `name.ar.io` (not `name.arweave.net`)
- [ ] Click an undername link → opens as `under_name.ar.io`
- [ ] Search for a taken name → displays `name.ar.io` text
- [ ] Returned names table links resolve to `ar.io`
- [ ] Banner shows "June 1, 2026" snapshot date
- [ ] Logo images still load correctly (uses data gateway, not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)