### PR TITLE
feat: atomic ArNS purchase (SDK spawns the ANT) + drop Target ID input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-18
+
+### Changed
+
+- Updated purchase flow to atomically spawn MPL core ANT + purchase ArNS name
+
 ## [2.2.0] - 2026-06-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^4.1.0-alpha.1",
+    "@ar.io/sdk": "^4.1.0-alpha.6",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^4.1.0-alpha.6",
+    "@ar.io/sdk": "^4.1.0-alpha.8",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -693,7 +693,7 @@ function Checkout() {
             <DomainCheckoutCard
               domain={transaction?.name}
               antId={transaction?.processId}
-              targetId={transaction?.targetId?.toString()}
+              targetId={undefined}
               orderSummary={orderSummary}
               fees={fees}
               quoteEndTimestamp={quoteEndTimestamp}

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -1,6 +1,5 @@
 import { CheckCircleFilled } from '@ant-design/icons';
 import { mARIOToken } from '@ar.io/sdk/web';
-import Tooltip from '@src/components/Tooltips/Tooltip';
 import { Accordion } from '@src/components/data-display';
 import { useLatestANTVersion } from '@src/hooks/useANTVersions';
 import { useArIoPrice } from '@src/hooks/useArIOPrice';

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -103,13 +103,14 @@ function RegisterNameForm() {
       });
       return;
     }
+
+    const contract = await buildAntRead({ processId: id.toString() });
+    if (!contract) throw new Error('Contract not found');
+
     dispatchRegisterState({
       type: 'setANTID',
       payload: id,
     });
-
-    const contract = await buildAntRead({ processId: id.toString() });
-    if (!contract) throw new Error('Contract not found');
   }
 
   if (!registrationType) {
@@ -415,7 +416,11 @@ function RegisterNameForm() {
             >
               <div className="flex flex-column" style={{ gap: '1em' }}>
                 <NameTokenSelector
-                  selectedTokenCallback={(id) => handleANTId(id)}
+                  selectedTokenCallback={(id) => {
+                    handleANTId(id).catch((error) => {
+                      eventEmitter.emit('error', error);
+                    });
+                  }}
                 />
               </div>
             </Accordion>

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -5,13 +5,12 @@ import { Accordion } from '@src/components/data-display';
 import { useLatestANTVersion } from '@src/hooks/useANTVersions';
 import { useArIoPrice } from '@src/hooks/useArIOPrice';
 import { useCostDetails } from '@src/hooks/useCostDetails';
-import { ValidationError } from '@src/utils/errors';
 import { buildAntRead } from '@src/utils/sdk-init';
 import emojiRegex from 'emoji-regex';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useIsFocused, useRegistrationStatus } from '../../../hooks';
+import { useRegistrationStatus } from '../../../hooks';
 import { ArweaveTransactionID } from '../../../services/arweave/ArweaveTransactionID';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
@@ -21,7 +20,6 @@ import {
   ARNS_INTERACTION_TYPES,
   BuyRecordPayload,
   TRANSACTION_TYPES,
-  VALIDATION_INPUT_TYPES,
 } from '../../../types';
 import {
   decodeDomainToASCII,
@@ -29,7 +27,6 @@ import {
   formatARIO,
   formatARIOWithCommas,
   formatDate,
-  isArweaveTransactionID,
 } from '../../../utils';
 import {
   ARNS_PURCHASES_DISABLED,
@@ -41,20 +38,19 @@ import eventEmitter from '../../../utils/events';
 import Counter from '../../inputs/Counter/Counter';
 import WorkflowButtons from '../../inputs/buttons/WorkflowButtons/WorkflowButtons';
 import NameTokenSelector from '../../inputs/text/NameTokenSelector/NameTokenSelector';
-import ValidationInput from '../../inputs/text/ValidationInput/ValidationInput';
 import Loader from '../../layout/Loader/Loader';
 import { StepProgressBar } from '../../layout/progress';
 import PageLoader from '../../layout/progress/PageLoader/PageLoader';
 import './styles.css';
 
 function RegisterNameForm() {
-  const [{ arweaveDataProvider, arioTicker }] = useGlobalState();
+  const [{ arioTicker }] = useGlobalState();
   // Legacy AO fields kept as no-op placeholders for the existing payload
   // shapes; the Solana dispatchers ignore them.
   const arioProcessId = '';
   const antRegistryProcessId = '';
   const [
-    { domain, leaseDuration, registrationType, antID, targetId },
+    { domain, leaseDuration, registrationType, antID },
     dispatchRegisterState,
   ] = useRegistrationState();
   const { data: costDetails } = useCostDetails({
@@ -81,11 +77,7 @@ function RegisterNameForm() {
   const { isLoading: isValidatingRegistration } = useRegistrationStatus(
     name ?? domain,
   );
-  const [newTargetId, setNewTargetId] = useState<string>();
-  const targetIdFocused = useIsFocused('target-id-input');
   const navigate = useNavigate();
-  const [hasValidationErrors, setHasValidationErrors] =
-    useState<boolean>(false);
   const [validatingNext, setValidatingNext] = useState<boolean>(false);
   const {
     data: antVersion,
@@ -152,12 +144,6 @@ function RegisterNameForm() {
       }
 
       setValidatingNext(true);
-
-      if (hasValidationErrors) {
-        throw new ValidationError(
-          'Please fix the errors above before continuing.',
-        );
-      }
     } catch (error: any) {
       eventEmitter.emit('error', error);
       setValidatingNext(false);
@@ -179,7 +165,6 @@ function RegisterNameForm() {
           ? leaseDuration
           : undefined,
       type: registrationType,
-      targetId,
       // antModuleId is the AO Lua module ID; on Solana there's no module
       // (ANTs are Metaplex Core NFTs). Cast through `any` to satisfy the
       // legacy `BuyRecordPayload` shape until the consumer type is split
@@ -430,70 +415,6 @@ function RegisterNameForm() {
               key="1"
             >
               <div className="flex flex-column" style={{ gap: '1em' }}>
-                <div
-                  className="name-token-input-wrapper"
-                  style={{
-                    border:
-                      targetIdFocused || newTargetId
-                        ? 'solid 1px var(--text-white)'
-                        : 'solid 1px var(--text-faded)',
-                    position: 'relative',
-                  }}
-                >
-                  <ValidationInput
-                    inputId={'target-id-input'}
-                    value={newTargetId ?? ''}
-                    setValue={(v: string) => {
-                      setNewTargetId(v.trim());
-                      if (isArweaveTransactionID(v.trim())) {
-                        dispatchRegisterState({
-                          type: 'setTargetId',
-                          payload: new ArweaveTransactionID(v.trim()),
-                        });
-                      }
-                      if (v.trim().length === 0) {
-                        setHasValidationErrors(false);
-                      }
-                    }}
-                    wrapperCustomStyle={{
-                      width: '100%',
-                      hieght: '45px',
-                      borderRadius: '0px',
-                      backgroundColor: 'var(--card-bg)',
-                      boxSizing: 'border-box',
-                    }}
-                    inputClassName={`white name-token-input`}
-                    inputCustomStyle={{
-                      paddingLeft: '10px',
-                      background: 'transparent',
-                    }}
-                    maxCharLength={43}
-                    placeholder={'Arweave Transaction ID (Target ID)'}
-                    validationPredicates={{
-                      [VALIDATION_INPUT_TYPES.ARWEAVE_ID]: {
-                        fn: (id: string) =>
-                          arweaveDataProvider.validateArweaveId(id),
-                      },
-                    }}
-                    showValidationChecklist={false}
-                    showValidationIcon={true}
-                    validityCallback={(validity: boolean) => {
-                      setHasValidationErrors(!validity);
-                    }}
-                  />
-
-                  <span
-                    className="flex flex-row text grey flex-center"
-                    style={{
-                      width: 'fit-content',
-                      height: 'fit-content',
-                      wordBreak: 'keep-all',
-                      // padding: '1px',
-                    }}
-                  >
-                    <Tooltip message="The Target ID is the Arweave Transaction ID that will be resolved at the root of this ArNS name" />
-                  </span>
-                </div>
                 <NameTokenSelector
                   selectedTokenCallback={(id) => handleANTId(id)}
                 />

--- a/src/components/pages/Transaction/TransactionReview.tsx
+++ b/src/components/pages/Transaction/TransactionReview.tsx
@@ -194,7 +194,6 @@ function TransactionReview() {
           compact={true}
           overrides={{
             ...antProps.overrides,
-            targetId: (transactionData as any)?.targetId?.toString(),
           }}
         />
 

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -115,31 +115,36 @@ export default async function dispatchArIOInteraction({
           );
         }
 
-        // Spawn the ANT first. On Solana this mints a Metaplex Core asset
-        // and bootstraps the ACL atomically.
-        let antProcessId: string;
-        if (payload.processId) {
-          antProcessId = payload.processId;
-        } else {
-          dispatch({
-            type: 'setSigningMessage',
-            payload: `Spawning new ANT for new ArNS name '${name}'`,
-          });
-          const { programIds } = getActiveSolanaConfig();
-          const spawnResult = await ANT.spawn({
-            rpc: getSolanaRpc(),
-            rpcSubscriptions: getSolanaRpcSubscriptions(),
-            signer: wallet.solanaSigner,
-            antProgramId: programIds.antProgramId,
-            state: {
-              ...createAntStateForOwner(owner.toString(), payload.targetId),
-              name,
-            },
-          });
-          antProcessId = spawnResult.processId;
-        }
+        // The user's existing ANT, when they chose to reuse one on the
+        // registration form. Undefined means "mint a fresh ANT for this name".
+        const existingAntProcessId: string | undefined = payload.processId;
 
         if (isReturnedName) {
+          // `buyReturnedName` does NOT support atomic ANT spawning (unlike
+          // `buyRecord`); it requires a real `processId`. So for returned names
+          // we still spawn the ANT first.
+          let antProcessId: string;
+          if (existingAntProcessId) {
+            antProcessId = existingAntProcessId;
+          } else {
+            dispatch({
+              type: 'setSigningMessage',
+              payload: `Spawning new ANT for returned name '${name}'`,
+            });
+            const { programIds } = getActiveSolanaConfig();
+            const spawnResult = await ANT.spawn({
+              rpc: getSolanaRpc(),
+              rpcSubscriptions: getSolanaRpcSubscriptions(),
+              signer: wallet.solanaSigner,
+              antProgramId: programIds.antProgramId,
+              state: {
+                ...createAntStateForOwner(owner.toString(), payload.targetId),
+                name,
+              },
+            });
+            antProcessId = spawnResult.processId;
+          }
+
           dispatch({
             type: 'setSigningMessage',
             payload: `Purchasing returned name '${name}' from auction`,
@@ -156,18 +161,42 @@ export default async function dispatchArIOInteraction({
             referrer: APP_NAME,
             paidBy,
           });
+          payload.processId = antProcessId;
         } else {
+          // Atomic purchase (ar.io SDK >= 4.1.0-alpha.5): when no `processId` is
+          // supplied, `buyRecord` mints a fresh ANT and assigns the name to it
+          // in the SAME transaction, returning the new ANT id as
+          // `result.result.processId`. The SDK routes balance/credit-funded
+          // buys inline (one signature) and only falls back to a multi-tx
+          // Address Lookup Table for large stake-funded plans that exceed the
+          // 1232-byte tx limit. Only pass `processId` when reusing an existing
+          // ANT; otherwise omit it and let the SDK spawn.
+          dispatch({
+            type: 'setSigningMessage',
+            payload: existingAntProcessId
+              ? `Purchasing '${name}'`
+              : `Purchasing '${name}' and spawning its ANT`,
+          });
           result = await arioContract.buyRecord({
             name: lowered,
             type,
             years,
-            processId: antProcessId,
+            ...(existingAntProcessId
+              ? { processId: existingAntProcessId }
+              : {}),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
             paidBy,
           });
+          // Surface the ANT (reused, or freshly spawned and reported by the
+          // SDK) so the Checkout success screen and transaction history can
+          // link to it.
+          payload.processId =
+            existingAntProcessId ??
+            (result as any)?.result?.processId ??
+            undefined;
         }
-        payload.processId = antProcessId;
+
         dispatch({
           type: 'setSigningMessage',
           payload: `Successfully purchased '${name}'`,

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -138,7 +138,7 @@ export default async function dispatchArIOInteraction({
               signer: wallet.solanaSigner,
               antProgramId: programIds.antProgramId,
               state: {
-                ...createAntStateForOwner(owner.toString(), payload.targetId),
+                ...createAntStateForOwner(owner.toString()),
                 name,
               },
             });
@@ -195,6 +195,13 @@ export default async function dispatchArIOInteraction({
             existingAntProcessId ??
             (result as any)?.result?.processId ??
             undefined;
+
+          if (!payload.processId) {
+            console.error(
+              '[dispatchArIOInteraction] Atomic buyRecord succeeded but no processId was returned by the SDK. Transaction ID:',
+              result?.id,
+            );
+          }
         }
 
         dispatch({

--- a/src/state/contexts/RegistrationState.tsx
+++ b/src/state/contexts/RegistrationState.tsx
@@ -20,7 +20,6 @@ export type RegistrationState = {
   targetID?: ArweaveTransactionID;
   antID?: ArweaveTransactionID;
   fee: { ar: number; [x: string]: number | undefined };
-  targetId?: ArweaveTransactionID;
   isRegistered: boolean;
   stage: number;
   isSearching: boolean;

--- a/src/state/contexts/RegistrationState.tsx
+++ b/src/state/contexts/RegistrationState.tsx
@@ -17,7 +17,6 @@ export type RegistrationState = {
   domain: string;
   leaseDuration: number;
   antContract?: ANTRead;
-  targetID?: ArweaveTransactionID;
   antID?: ArweaveTransactionID;
   fee: { ar: number; [x: string]: number | undefined };
   isRegistered: boolean;

--- a/src/state/reducers/RegistrationReducer.ts
+++ b/src/state/reducers/RegistrationReducer.ts
@@ -7,7 +7,6 @@ import {
 
 export type RegistrationAction =
   | { type: 'setDomainName'; payload: string }
-  | { type: 'setTargetId'; payload: ArweaveTransactionID }
   | { type: 'setRegistrationType'; payload: TRANSACTION_TYPES }
   | { type: 'setLeaseDuration'; payload: number }
   | { type: 'setANTID'; payload: ArweaveTransactionID | undefined }
@@ -36,11 +35,6 @@ export const registrationReducer = (
       return {
         ...state,
         domain: action.payload,
-      };
-    case 'setTargetId':
-      return {
-        ...state,
-        targetId: action.payload,
       };
     case 'setLeaseDuration':
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -356,7 +356,6 @@ export type BuyRecordPayload = {
   years?: number;
   type: TRANSACTION_TYPES;
   qty?: number; // the cost displayed to the user when buying a record
-  targetId?: ArweaveTransactionID;
   antModuleId: string;
   antRegistryId: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,12 +131,12 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@^4.1.0-alpha.6":
-  version "4.1.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.6.tgz#635e803bbf6c794aaf28ad06d13660d959f19cab"
-  integrity sha512-2OYXbh+MO06CFPlPs0QtsYp5LN9ZbWTMA/6E2GhUGVniGxviRpEwFhN5D31lK3mQur1Nfw8ku9idqPWs3sLLbg==
+"@ar.io/sdk@^4.1.0-alpha.8":
+  version "4.1.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.8.tgz#29bd99523b2cb81b93af55abf6b2d57cbee236c9"
+  integrity sha512-9izmIDpCrcGpzM7BUesAhKFXQ54Ek6ASsfUx1gG2a8A8DudDa7j2kgTN3cPOUMBieLkdwgtWkg8WxhyGclJVDA==
   dependencies:
-    "@ar.io/solana-contracts" "1.0.1"
+    "@ar.io/solana-contracts" "1.0.0-staging.22"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -156,10 +156,10 @@
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"
 
-"@ar.io/solana-contracts@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
-  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
+"@ar.io/solana-contracts@1.0.0-staging.22":
+  version "1.0.0-staging.22"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0-staging.22.tgz#51a2f896828fc2394cb9a1bdb591cb995f51aecb"
+  integrity sha512-W/v1xE/9xeKyH7FxOQSI5keKfSzR8oVaMyv4gtcE1pte2BNQP2MB8FzQ2nDKHO+/ByAtmLfJQceDjrGuSP+LPg==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,10 +131,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@^4.1.0-alpha.1":
-  version "4.1.0-alpha.1"
-  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-4.1.0-alpha.1.tgz#97c4040562b76628419e4d658995f0aeb9d8c5ff"
-  integrity sha512-ggJqbEqR2NAp4Vs7gzTSocf6Oe6kCl5Rz5q88Oy0v+OSKnAslzvYQ51SacClQ3TYEOiGrXZVSw2JgamP445RbQ==
+"@ar.io/sdk@^4.1.0-alpha.6":
+  version "4.1.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.6.tgz#635e803bbf6c794aaf28ad06d13660d959f19cab"
+  integrity sha512-2OYXbh+MO06CFPlPs0QtsYp5LN9ZbWTMA/6E2GhUGVniGxviRpEwFhN5D31lK3mQur1Nfw8ku9idqPWs3sLLbg==
   dependencies:
     "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
## Summary

Uses the ar.io SDK's atomic purchase (`@ar.io/sdk` **4.1.0-alpha.6**) so buying a name spawns its ANT in the same flow instead of pre-spawning a separate transaction, and removes the Target ID input from the register form.

## Changes

### Atomic `buyRecord` (`dispatchArIOInteraction`)
- The `BUY_RECORD` workflow no longer pre-spawns the ANT. When the user isn't reusing an existing ANT, it calls `buyRecord` **without** `processId`; the SDK mints the ANT and assigns the name atomically and returns the new ANT id as `result.result.processId`, which we surface to the checkout/history.
- Reusing an existing ANT still passes `processId`.
- **Returned names** still pre-spawn — `buyReturnedName` is not atomic in the SDK.
- Requires the SDK fixes in [ar-io/ar-io-sdk#696](https://github.com/ar-io/ar-io-sdk/pull/696) (published in 4.1.0-alpha.6): balance/credit buys go inline in one signature; large stake-funded plans route through an address lookup table to stay under the 1232-byte tx limit; and the post-spawn ACL bootstrap is decoupled from `sync_attributes` so ownership records reliably.

### Remove Target ID input (register form)
- Dropped the Target ID field from "Advanced Options" — it added bytes to the purchase tx and can be set after registration from **Domain Settings → Target ID**.
- Removed its input/validation/focus state and the now-dead `setTargetId` reducer action + `targetId` registration-state field. The ANT selector in Advanced Options is unchanged.

## Testing
- Verified against a live devnet cluster: a balance-funded buy spawns a real ANT, records ownership (no manual "sync ownership" prompt), and a large stake-funded buy lands via the lookup-table path.
- Typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated name registration to select an ANT directly, replacing the “Target ID” step.
  - Added support for atomically creating an ANT during name purchases or reusing an existing ANT.

- **Bug Fixes**
  - Improved purchase and returned-name flows to maintain the correct ANT throughout checkout and transaction processing.
  - Removed outdated Target ID validation and checkout references.

- **Chores**
  - Released version 2.3.0 and added the corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->