### PR TITLE
Production: atomic ArNS purchase on @ar.io/sdk 4.1.0-alpha.8 (ant #118 cutover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-18
+
+### Changed
+
+- Updated purchase flow to atomically spawn MPL core ANT + purchase ArNS name
+
 ## [2.2.0] - 2026-06-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^4.1.0-alpha.1",
+    "@ar.io/sdk": "^4.1.0-alpha.8",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -693,7 +693,7 @@ function Checkout() {
             <DomainCheckoutCard
               domain={transaction?.name}
               antId={transaction?.processId}
-              targetId={transaction?.targetId?.toString()}
+              targetId={undefined}
               orderSummary={orderSummary}
               fees={fees}
               quoteEndTimestamp={quoteEndTimestamp}

--- a/src/components/pages/Register/Register.tsx
+++ b/src/components/pages/Register/Register.tsx
@@ -1,17 +1,15 @@
 import { CheckCircleFilled } from '@ant-design/icons';
 import { mARIOToken } from '@ar.io/sdk/web';
-import Tooltip from '@src/components/Tooltips/Tooltip';
 import { Accordion } from '@src/components/data-display';
 import { useLatestANTVersion } from '@src/hooks/useANTVersions';
 import { useArIoPrice } from '@src/hooks/useArIOPrice';
 import { useCostDetails } from '@src/hooks/useCostDetails';
-import { ValidationError } from '@src/utils/errors';
 import { buildAntRead } from '@src/utils/sdk-init';
 import emojiRegex from 'emoji-regex';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useIsFocused, useRegistrationStatus } from '../../../hooks';
+import { useRegistrationStatus } from '../../../hooks';
 import { ArweaveTransactionID } from '../../../services/arweave/ArweaveTransactionID';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
 import { useRegistrationState } from '../../../state/contexts/RegistrationState';
@@ -21,7 +19,6 @@ import {
   ARNS_INTERACTION_TYPES,
   BuyRecordPayload,
   TRANSACTION_TYPES,
-  VALIDATION_INPUT_TYPES,
 } from '../../../types';
 import {
   decodeDomainToASCII,
@@ -29,7 +26,6 @@ import {
   formatARIO,
   formatARIOWithCommas,
   formatDate,
-  isArweaveTransactionID,
 } from '../../../utils';
 import {
   ARNS_PURCHASES_DISABLED,
@@ -41,20 +37,19 @@ import eventEmitter from '../../../utils/events';
 import Counter from '../../inputs/Counter/Counter';
 import WorkflowButtons from '../../inputs/buttons/WorkflowButtons/WorkflowButtons';
 import NameTokenSelector from '../../inputs/text/NameTokenSelector/NameTokenSelector';
-import ValidationInput from '../../inputs/text/ValidationInput/ValidationInput';
 import Loader from '../../layout/Loader/Loader';
 import { StepProgressBar } from '../../layout/progress';
 import PageLoader from '../../layout/progress/PageLoader/PageLoader';
 import './styles.css';
 
 function RegisterNameForm() {
-  const [{ arweaveDataProvider, arioTicker }] = useGlobalState();
+  const [{ arioTicker }] = useGlobalState();
   // Legacy AO fields kept as no-op placeholders for the existing payload
   // shapes; the Solana dispatchers ignore them.
   const arioProcessId = '';
   const antRegistryProcessId = '';
   const [
-    { domain, leaseDuration, registrationType, antID, targetId },
+    { domain, leaseDuration, registrationType, antID },
     dispatchRegisterState,
   ] = useRegistrationState();
   const { data: costDetails } = useCostDetails({
@@ -81,11 +76,7 @@ function RegisterNameForm() {
   const { isLoading: isValidatingRegistration } = useRegistrationStatus(
     name ?? domain,
   );
-  const [newTargetId, setNewTargetId] = useState<string>();
-  const targetIdFocused = useIsFocused('target-id-input');
   const navigate = useNavigate();
-  const [hasValidationErrors, setHasValidationErrors] =
-    useState<boolean>(false);
   const [validatingNext, setValidatingNext] = useState<boolean>(false);
   const {
     data: antVersion,
@@ -112,13 +103,14 @@ function RegisterNameForm() {
       });
       return;
     }
+
+    const contract = await buildAntRead({ processId: id.toString() });
+    if (!contract) throw new Error('Contract not found');
+
     dispatchRegisterState({
       type: 'setANTID',
       payload: id,
     });
-
-    const contract = await buildAntRead({ processId: id.toString() });
-    if (!contract) throw new Error('Contract not found');
   }
 
   if (!registrationType) {
@@ -152,12 +144,6 @@ function RegisterNameForm() {
       }
 
       setValidatingNext(true);
-
-      if (hasValidationErrors) {
-        throw new ValidationError(
-          'Please fix the errors above before continuing.',
-        );
-      }
     } catch (error: any) {
       eventEmitter.emit('error', error);
       setValidatingNext(false);
@@ -179,7 +165,6 @@ function RegisterNameForm() {
           ? leaseDuration
           : undefined,
       type: registrationType,
-      targetId,
       // antModuleId is the AO Lua module ID; on Solana there's no module
       // (ANTs are Metaplex Core NFTs). Cast through `any` to satisfy the
       // legacy `BuyRecordPayload` shape until the consumer type is split
@@ -430,72 +415,12 @@ function RegisterNameForm() {
               key="1"
             >
               <div className="flex flex-column" style={{ gap: '1em' }}>
-                <div
-                  className="name-token-input-wrapper"
-                  style={{
-                    border:
-                      targetIdFocused || newTargetId
-                        ? 'solid 1px var(--text-white)'
-                        : 'solid 1px var(--text-faded)',
-                    position: 'relative',
-                  }}
-                >
-                  <ValidationInput
-                    inputId={'target-id-input'}
-                    value={newTargetId ?? ''}
-                    setValue={(v: string) => {
-                      setNewTargetId(v.trim());
-                      if (isArweaveTransactionID(v.trim())) {
-                        dispatchRegisterState({
-                          type: 'setTargetId',
-                          payload: new ArweaveTransactionID(v.trim()),
-                        });
-                      }
-                      if (v.trim().length === 0) {
-                        setHasValidationErrors(false);
-                      }
-                    }}
-                    wrapperCustomStyle={{
-                      width: '100%',
-                      hieght: '45px',
-                      borderRadius: '0px',
-                      backgroundColor: 'var(--card-bg)',
-                      boxSizing: 'border-box',
-                    }}
-                    inputClassName={`white name-token-input`}
-                    inputCustomStyle={{
-                      paddingLeft: '10px',
-                      background: 'transparent',
-                    }}
-                    maxCharLength={43}
-                    placeholder={'Arweave Transaction ID (Target ID)'}
-                    validationPredicates={{
-                      [VALIDATION_INPUT_TYPES.ARWEAVE_ID]: {
-                        fn: (id: string) =>
-                          arweaveDataProvider.validateArweaveId(id),
-                      },
-                    }}
-                    showValidationChecklist={false}
-                    showValidationIcon={true}
-                    validityCallback={(validity: boolean) => {
-                      setHasValidationErrors(!validity);
-                    }}
-                  />
-
-                  <span
-                    className="flex flex-row text grey flex-center"
-                    style={{
-                      width: 'fit-content',
-                      height: 'fit-content',
-                      wordBreak: 'keep-all',
-                      // padding: '1px',
-                    }}
-                  >
-                    <Tooltip message="The Target ID is the Arweave Transaction ID that will be resolved at the root of this ArNS name" />
-                  </span>
-                </div>
                 <NameTokenSelector
-                  selectedTokenCallback={(id) => handleANTId(id)}
+                  selectedTokenCallback={(id) => {
+                    handleANTId(id).catch((error) => {
+                      eventEmitter.emit('error', error);
+                    });
+                  }}
                 />
               </div>
             </Accordion>

--- a/src/components/pages/Transaction/TransactionReview.tsx
+++ b/src/components/pages/Transaction/TransactionReview.tsx
@@ -194,7 +194,6 @@ function TransactionReview() {
           compact={true}
           overrides={{
             ...antProps.overrides,
-            targetId: (transactionData as any)?.targetId?.toString(),
           }}
         />
 

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -115,31 +115,36 @@ export default async function dispatchArIOInteraction({
           );
         }
 
-        // Spawn the ANT first. On Solana this mints a Metaplex Core asset
-        // and bootstraps the ACL atomically.
-        let antProcessId: string;
-        if (payload.processId) {
-          antProcessId = payload.processId;
-        } else {
-          dispatch({
-            type: 'setSigningMessage',
-            payload: `Spawning new ANT for new ArNS name '${name}'`,
-          });
-          const { programIds } = getActiveSolanaConfig();
-          const spawnResult = await ANT.spawn({
-            rpc: getSolanaRpc(),
-            rpcSubscriptions: getSolanaRpcSubscriptions(),
-            signer: wallet.solanaSigner,
-            antProgramId: programIds.antProgramId,
-            state: {
-              ...createAntStateForOwner(owner.toString(), payload.targetId),
-              name,
-            },
-          });
-          antProcessId = spawnResult.processId;
-        }
+        // The user's existing ANT, when they chose to reuse one on the
+        // registration form. Undefined means "mint a fresh ANT for this name".
+        const existingAntProcessId: string | undefined = payload.processId;
 
         if (isReturnedName) {
+          // `buyReturnedName` does NOT support atomic ANT spawning (unlike
+          // `buyRecord`); it requires a real `processId`. So for returned names
+          // we still spawn the ANT first.
+          let antProcessId: string;
+          if (existingAntProcessId) {
+            antProcessId = existingAntProcessId;
+          } else {
+            dispatch({
+              type: 'setSigningMessage',
+              payload: `Spawning new ANT for returned name '${name}'`,
+            });
+            const { programIds } = getActiveSolanaConfig();
+            const spawnResult = await ANT.spawn({
+              rpc: getSolanaRpc(),
+              rpcSubscriptions: getSolanaRpcSubscriptions(),
+              signer: wallet.solanaSigner,
+              antProgramId: programIds.antProgramId,
+              state: {
+                ...createAntStateForOwner(owner.toString()),
+                name,
+              },
+            });
+            antProcessId = spawnResult.processId;
+          }
+
           dispatch({
             type: 'setSigningMessage',
             payload: `Purchasing returned name '${name}' from auction`,
@@ -156,18 +161,49 @@ export default async function dispatchArIOInteraction({
             referrer: APP_NAME,
             paidBy,
           });
+          payload.processId = antProcessId;
         } else {
+          // Atomic purchase (ar.io SDK >= 4.1.0-alpha.5): when no `processId` is
+          // supplied, `buyRecord` mints a fresh ANT and assigns the name to it
+          // in the SAME transaction, returning the new ANT id as
+          // `result.result.processId`. The SDK routes balance/credit-funded
+          // buys inline (one signature) and only falls back to a multi-tx
+          // Address Lookup Table for large stake-funded plans that exceed the
+          // 1232-byte tx limit. Only pass `processId` when reusing an existing
+          // ANT; otherwise omit it and let the SDK spawn.
+          dispatch({
+            type: 'setSigningMessage',
+            payload: existingAntProcessId
+              ? `Purchasing '${name}'`
+              : `Purchasing '${name}' and spawning its ANT`,
+          });
           result = await arioContract.buyRecord({
             name: lowered,
             type,
             years,
-            processId: antProcessId,
+            ...(existingAntProcessId
+              ? { processId: existingAntProcessId }
+              : {}),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
             paidBy,
           });
+          // Surface the ANT (reused, or freshly spawned and reported by the
+          // SDK) so the Checkout success screen and transaction history can
+          // link to it.
+          payload.processId =
+            existingAntProcessId ??
+            (result as any)?.result?.processId ??
+            undefined;
+
+          if (!payload.processId) {
+            console.error(
+              '[dispatchArIOInteraction] Atomic buyRecord succeeded but no processId was returned by the SDK. Transaction ID:',
+              result?.id,
+            );
+          }
         }
-        payload.processId = antProcessId;
+
         dispatch({
           type: 'setSigningMessage',
           payload: `Successfully purchased '${name}'`,

--- a/src/state/contexts/RegistrationState.tsx
+++ b/src/state/contexts/RegistrationState.tsx
@@ -17,10 +17,8 @@ export type RegistrationState = {
   domain: string;
   leaseDuration: number;
   antContract?: ANTRead;
-  targetID?: ArweaveTransactionID;
   antID?: ArweaveTransactionID;
   fee: { ar: number; [x: string]: number | undefined };
-  targetId?: ArweaveTransactionID;
   isRegistered: boolean;
   stage: number;
   isSearching: boolean;

--- a/src/state/reducers/RegistrationReducer.ts
+++ b/src/state/reducers/RegistrationReducer.ts
@@ -7,7 +7,6 @@ import {
 
 export type RegistrationAction =
   | { type: 'setDomainName'; payload: string }
-  | { type: 'setTargetId'; payload: ArweaveTransactionID }
   | { type: 'setRegistrationType'; payload: TRANSACTION_TYPES }
   | { type: 'setLeaseDuration'; payload: number }
   | { type: 'setANTID'; payload: ArweaveTransactionID | undefined }
@@ -36,11 +35,6 @@ export const registrationReducer = (
       return {
         ...state,
         domain: action.payload,
-      };
-    case 'setTargetId':
-      return {
-        ...state,
-        targetId: action.payload,
       };
     case 'setLeaseDuration':
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -356,7 +356,6 @@ export type BuyRecordPayload = {
   years?: number;
   type: TRANSACTION_TYPES;
   qty?: number; // the cost displayed to the user when buying a record
-  targetId?: ArweaveTransactionID;
   antModuleId: string;
   antRegistryId: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,12 +131,12 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@^4.1.0-alpha.1":
-  version "4.1.0-alpha.1"
-  resolved "https://registry.npmjs.org/@ar.io/sdk/-/sdk-4.1.0-alpha.1.tgz#97c4040562b76628419e4d658995f0aeb9d8c5ff"
-  integrity sha512-ggJqbEqR2NAp4Vs7gzTSocf6Oe6kCl5Rz5q88Oy0v+OSKnAslzvYQ51SacClQ3TYEOiGrXZVSw2JgamP445RbQ==
+"@ar.io/sdk@^4.1.0-alpha.8":
+  version "4.1.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.8.tgz#29bd99523b2cb81b93af55abf6b2d57cbee236c9"
+  integrity sha512-9izmIDpCrcGpzM7BUesAhKFXQ54Ek6ASsfUx1gG2a8A8DudDa7j2kgTN3cPOUMBieLkdwgtWkg8WxhyGclJVDA==
   dependencies:
-    "@ar.io/solana-contracts" "1.0.1"
+    "@ar.io/solana-contracts" "1.0.0-staging.22"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -156,10 +156,10 @@
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"
 
-"@ar.io/solana-contracts@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
-  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
+"@ar.io/solana-contracts@1.0.0-staging.22":
+  version "1.0.0-staging.22"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0-staging.22.tgz#51a2f896828fc2394cb9a1bdb591cb995f51aecb"
+  integrity sha512-W/v1xE/9xeKyH7FxOQSI5keKfSzR8oVaMyv4gtcE1pte2BNQP2MB8FzQ2nDKHO+/ByAtmLfJQceDjrGuSP+LPg==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Promotes #958 (atomic ArNS purchase — SDK spawns the ANT) to production. Ships **only** #958.

**⚠️ COORDINATED CUTOVER — timing matters.** The portal now uses `@ar.io/sdk@4.1.0-alpha.8`, whose `buyRecord` bundles the **ADR-028** `sync_attributes` (ant_authority PDA) form. This requires the **mainnet ant program (#118)** to be live.

Merging this triggers the ar.io production deploy. The mainnet ant #118 upgrade is staged and will be deployed **the instant this deploy goes live** (buffer ready), so there is no window where the new portal runs against the old ant program. The **old portal keeps serving during the build**, so live buys keep working until the new portal is live.

- develop == main + this one commit (clean promote)
- Rollback: ant #118 is not `--final` (backup ready); portal revertable to prior main

Do not merge until the deploy operator (watching the ant #118 buffer) is ready to fire the on-chain upgrade at go-live.