### PR TITLE
fix: upgrade @ar.io/sdk to 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ## [2.3.1] - 2026-08-10
 
+### Changed
+
+- Upgraded `@ar.io/sdk` to 4.1.1 (fixes atomic ArNS registration bug)
+
 ### Fixed
 
 - Prevent double-click submission on all transaction confirm/pay buttons

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "^4.1.0-alpha.8",
+    "@ar.io/sdk": "4.1.1",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,12 +131,12 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@^4.1.0-alpha.8":
-  version "4.1.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.8.tgz#29bd99523b2cb81b93af55abf6b2d57cbee236c9"
-  integrity sha512-9izmIDpCrcGpzM7BUesAhKFXQ54Ek6ASsfUx1gG2a8A8DudDa7j2kgTN3cPOUMBieLkdwgtWkg8WxhyGclJVDA==
+"@ar.io/sdk@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.1.tgz#d9932b47c308d45e8b8315150cc2bf5afd55b4e1"
+  integrity sha512-a0mg6emlmWpzuV2OrVnBikTO7tkjyiiIzK3nbM/wH6CG+YQEcN2+S8N+m0HlixjeOfK/G1rOEnt82NO1vSXF/w==
   dependencies:
-    "@ar.io/solana-contracts" "1.0.0-staging.22"
+    "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -156,10 +156,10 @@
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"
 
-"@ar.io/solana-contracts@1.0.0-staging.22":
-  version "1.0.0-staging.22"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0-staging.22.tgz#51a2f896828fc2394cb9a1bdb591cb995f51aecb"
-  integrity sha512-W/v1xE/9xeKyH7FxOQSI5keKfSzR8oVaMyv4gtcE1pte2BNQP2MB8FzQ2nDKHO+/ByAtmLfJQceDjrGuSP+LPg==
+"@ar.io/solana-contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
+  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
## Summary

- Upgrades `@ar.io/sdk` from `4.1.0-alpha.8` to `4.1.1`
- Fixes a bug with atomic ArNS name registration
- Bumps version to 2.3.1

## Test plan

- [x] `yarn build` succeeds
- [ ] Manual test: atomic ArNS name registration flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)