### PR TITLE
fix: harden purchase flow against double-click and improve error handling

### DIFF
--- a/src/components/modals/PrimaryNameModal/PrimaryNameModal.tsx
+++ b/src/components/modals/PrimaryNameModal/PrimaryNameModal.tsx
@@ -101,7 +101,8 @@ function PrimaryNameModal({
   const { data: primaryNameData, isLoading: isLoadingPrimaryNameData } =
     usePrimaryName();
 
-  const [{ transactionData }, dispatchTransactionState] = useTransactionState();
+  const [{ transactionData, signing }, dispatchTransactionState] =
+    useTransactionState();
   const [, dispatchArNSState] = useArNSState();
 
   const [fundingSource, setFundingSource] = useState<FundFrom>('balance');
@@ -517,6 +518,7 @@ function PrimaryNameModal({
         onNext={
           !isLoading &&
           !isLoadingCostDetail &&
+          !signing &&
           costDetail &&
           (workflow === PRIMARY_NAME_WORKFLOWS.REMOVE ||
             (!isInsufficientBalance && !isInsufficientSolForGas))

--- a/src/components/modals/PrimaryNameModal/PrimaryNameModal.tsx
+++ b/src/components/modals/PrimaryNameModal/PrimaryNameModal.tsx
@@ -513,8 +513,8 @@ function PrimaryNameModal({
             </div>
           )
         }
-        onCancel={closeModal}
-        onClose={closeModal}
+        onCancel={!signing ? closeModal : undefined}
+        onClose={!signing ? closeModal : undefined}
         onNext={
           !isLoading &&
           !isLoadingCostDetail &&

--- a/src/components/modals/ant-management/ReassignNameModal/ReassignNameModal.tsx
+++ b/src/components/modals/ant-management/ReassignNameModal/ReassignNameModal.tsx
@@ -529,6 +529,7 @@ export function ReassignNameModal({
               ? isValidAoAddress(newAntProcessId) && !loadingNewAntInfo
               : true) &&
             accepted &&
+            !signing &&
             !isInsufficientSolForGas
               ? () => handleReassign()
               : undefined

--- a/src/components/modals/ant-management/ReturnNameModal/ReturnNameModal.tsx
+++ b/src/components/modals/ant-management/ReturnNameModal/ReturnNameModal.tsx
@@ -155,7 +155,7 @@ export function ReturnNameModal({
         nextText="Confirm"
         onCancel={!signing ? () => setShow(false) : undefined}
         onClose={!signing ? () => setShow(false) : undefined}
-        onNext={accepted ? () => handleReturn() : undefined}
+        onNext={accepted && !signing ? () => handleReturn() : undefined}
         footerClass={'py-10'}
       />
     </div>

--- a/src/components/pages/Register/Checkout.tsx
+++ b/src/components/pages/Register/Checkout.tsx
@@ -74,7 +74,13 @@ function Checkout() {
   const { data: creditsBalance } = useTurboCreditBalance();
   const { data: solBalance } = useSolBalance();
   const [
-    { workflowName, interactionType, transactionData, interactionResult },
+    {
+      workflowName,
+      interactionType,
+      transactionData,
+      interactionResult,
+      signing,
+    },
     dispatchTransactionState,
   ] = useTransactionState();
   const transaction = transactionData as BuyRecordPayload;
@@ -716,6 +722,7 @@ function Checkout() {
                 workflowName === ARNS_INTERACTION_TYPES.UPGRADE_NAME;
               const payDisabled =
                 (ARNS_PURCHASES_DISABLED && isNewPurchase) ||
+                signing ||
                 isInsufficientBalance ||
                 isInsufficientSolForGas ||
                 isLoadingCostDetail ||

--- a/src/components/pages/Transaction/TransactionReview.tsx
+++ b/src/components/pages/Transaction/TransactionReview.tsx
@@ -42,7 +42,13 @@ function TransactionReview() {
   const [, dispatchArNSState] = useArNSState();
   const [{ walletAddress, wallet }] = useWalletState();
   const [
-    { workflowName, interactionType, transactionData, interactionResult },
+    {
+      workflowName,
+      interactionType,
+      transactionData,
+      interactionResult,
+      signing,
+    },
     dispatchTransactionState,
   ] = useTransactionState();
   const isMobile = useIsMobile();
@@ -214,6 +220,7 @@ function TransactionReview() {
         >
           <WorkflowButtons
             onNext={
+              signing ||
               !costDetail ||
               (costDetail.fundingPlan?.shortfall &&
                 costDetail.fundingPlan?.shortfall > 0)

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -152,15 +152,29 @@ export default async function dispatchArIOInteraction({
           // `buyReturnedName` is Solana-only — same pattern as the
           // `releaseName`/`reassignName` casts in `dispatchANTInteraction`.
           // Phase 7 should hoist it onto the shared `ARIOWrite` interface.
-          result = await (arioContract as any).buyReturnedName({
-            name: lowered,
-            type,
-            years,
-            processId: antProcessId,
-            fundFrom: originalFundFrom,
-            referrer: APP_NAME,
-            paidBy,
-          });
+          try {
+            result = await (arioContract as any).buyReturnedName({
+              name: lowered,
+              type,
+              years,
+              processId: antProcessId,
+              fundFrom: originalFundFrom,
+              referrer: APP_NAME,
+              paidBy,
+            });
+          } catch (buyError: any) {
+            // If we spawned a fresh ANT but the purchase failed, tell the
+            // user about the orphaned ANT so they can reuse it on retry.
+            if (!existingAntProcessId) {
+              const msg = buyError?.message ?? String(buyError);
+              throw new Error(
+                `Failed to purchase returned name '${name}': ${msg}. ` +
+                  `A new ANT was already created (${antProcessId}). ` +
+                  `You can reuse it by selecting it under Advanced Options when retrying.`,
+              );
+            }
+            throw buyError;
+          }
           payload.processId = antProcessId;
         } else {
           // Atomic purchase (ar.io SDK >= 4.1.0-alpha.5): when no `processId` is
@@ -197,9 +211,8 @@ export default async function dispatchArIOInteraction({
             undefined;
 
           if (!payload.processId) {
-            console.error(
-              '[dispatchArIOInteraction] Atomic buyRecord succeeded but no processId was returned by the SDK. Transaction ID:',
-              result?.id,
+            throw new Error(
+              `Name '${name}' was purchased (tx: ${result?.id}) but the SDK did not return the ANT process ID. Check the transaction on-chain or contact support.`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- **Double-click prevention**: Gate all confirm/pay buttons on the `signing` state flag across 5 components: Checkout, TransactionReview, PrimaryNameModal, ReassignNameModal, and ReturnNameModal. Previously, rapid clicks could dispatch duplicate on-chain transactions.
- **Orphaned ANT error enrichment**: When `buyReturnedName` fails after a fresh ANT was already spawned, the error message now includes the orphaned ANT's process ID so the user can reuse it on retry instead of losing it.
- **Missing processId after atomic buy**: Changed silent `console.error` to a thrown error when the SDK's atomic `buyRecord` succeeds but doesn't return a processId — prevents a downstream crash on the success screen (`getLinkId` expects a non-null processId).

## Files changed

| File | Change |
|------|--------|
| `Checkout.tsx` | Added `signing` guard to "Pay now" button |
| `TransactionReview.tsx` | Added `signing` guard to "Confirm" button |
| `PrimaryNameModal.tsx` | Added `signing` guard to confirm button |
| `ReassignNameModal.tsx` | Added `signing` guard to confirm button |
| `ReturnNameModal.tsx` | Added `signing` guard to confirm button |
| `dispatchArIOInteraction.ts` | Orphaned ANT error enrichment + processId throw |

## Test plan

- [ ] Attempt rapid double-click on "Pay now" during name purchase — second click should be ignored
- [ ] Attempt rapid double-click on "Confirm" during extend lease / increase undernames — second click should be ignored
- [ ] Attempt rapid double-click on primary name set/remove confirm — second click should be ignored
- [ ] Attempt rapid double-click on reassign name confirm — second click should be ignored
- [ ] Attempt rapid double-click on return name confirm — second click should be ignored
- [ ] Purchase a returned name with a fresh ANT, simulate RPC failure — error should mention orphaned ANT processId
- [ ] Verify normal purchase flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate confirmations and payments while transactions are signing.
  * Improved error handling for returned-name purchases, including clearer recovery guidance when a newly created asset cannot be used.
  * Added explicit errors when required transaction details are unavailable during record purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->