### PR TITLE
fix: use wallet tokenType for Turbo credit balance endpoint

### DIFF
--- a/src/hooks/useTurboArNSClient.tsx
+++ b/src/hooks/useTurboArNSClient.tsx
@@ -20,6 +20,7 @@ export function useTurboArNSClient() {
     }
     return new TurboArNSClient({
       walletAddress: walletAddress?.toString(),
+      tokenType: wallet?.tokenType,
       paymentUrl: turboNetwork.PAYMENT_URL,
       stripe,
     });

--- a/src/services/turbo/TurboArNSClient.ts
+++ b/src/services/turbo/TurboArNSClient.ts
@@ -39,6 +39,8 @@ export interface TurboArNSClientConfig {
   // back-compat; Solana support requires the Turbo payment service update.
   signer?: any;
   walletAddress?: string;
+  /** Explicit token type from the connected wallet — avoids fragile address-format guessing. */
+  tokenType?: TokenType;
   stripe: Stripe;
   ao?: any;
 }
@@ -138,6 +140,7 @@ export class TurboArNSClient {
     walletsUrl = NETWORK_DEFAULTS.TURBO.WALLETS_URL,
     signer,
     walletAddress,
+    tokenType,
     stripe,
     ao = connect(NETWORK_DEFAULTS.AO.ARIO),
   }: TurboArNSClientConfig) {
@@ -149,6 +152,17 @@ export class TurboArNSClient {
     this.walletAddress = walletAddress;
     this.stripe = stripe;
     this.ao = ao;
+    // Prefer the explicit tokenType from the wallet connector; fall back to
+    // address-format detection only when the caller didn't supply one.
+    const resolvedToken: TokenType | undefined =
+      tokenType ??
+      (isArweaveTransactionID(this.walletAddress)
+        ? 'arweave'
+        : isEthAddress(this.walletAddress ?? '')
+          ? 'ethereum'
+          : isValidSolanaAddress(this.walletAddress ?? '')
+            ? 'solana'
+            : undefined);
     this.turboUploader = TurboFactory.unauthenticated({
       paymentServiceConfig: {
         url: this.paymentUrl,
@@ -157,13 +171,7 @@ export class TurboArNSClient {
         url: this.uploadUrl,
       },
       gatewayUrl: this.gatewayUrl,
-      token: isArweaveTransactionID(this.walletAddress)
-        ? 'arweave'
-        : isEthAddress(this.walletAddress ?? '')
-          ? 'ethereum'
-          : isValidSolanaAddress(this.walletAddress ?? '')
-            ? 'solana'
-            : undefined,
+      token: resolvedToken,
     });
     this.arioProcessId =
       this.paymentUrl === devPaymentServiceFqdn


### PR DESCRIPTION
## Summary

- Fixes 404 error when fetching Turbo credit balance for Solana users
- The `TurboArNSClient` was guessing token type from the wallet address format — when detection failed (e.g., address undefined during init), it defaulted to `'arweave'`, hitting `/v1/account/balance/arweave?address=<solana-addr>` which returns 404
- Now accepts an explicit `tokenType` from the wallet connector (`wallet.tokenType`), falling back to address-format detection only when not supplied

## Files changed

| File | Change |
|------|--------|
| `TurboArNSClient.ts` | Added `tokenType` to config, prefer it over address guessing |
| `useTurboArNSClient.tsx` | Pass `wallet.tokenType` to client constructor |

## Test plan

- [ ] Log in with Solana wallet, verify Turbo credit balance loads (no 404 in network tab)
- [ ] Verify balance endpoint uses `/v1/account/balance/solana?address=...`
- [ ] Verify Turbo top-up flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet token detection when connecting to Turbo services.
  * Preserved fallback detection for wallets whose token type is not explicitly provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->