### PR TITLE
fix: atomic buy default target ID + optimize manage page load

### DIFF
--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -197,7 +197,9 @@ export default async function dispatchArIOInteraction({
             years,
             ...(existingAntProcessId
               ? { processId: existingAntProcessId }
-              : {}),
+              : {
+                  antState: createAntStateForOwner(owner.toString()),
+                }),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
             paidBy,


### PR DESCRIPTION
## Summary
- **Wrong default target ID**: When `buyRecord` is called without an existing ANT (atomic purchase), the SDK defaults the `@` record's `transactionId` to `ARIO_LOGO_TX_ID` — the ar.io logo. Fix: pass `antState: createAntStateForOwner()` which sets `transactionId` to `LANDING_PAGE_TXID`
- **Manage page scanning entire registry**: `useDomainInfo` called `getArNSRecords` (plural) with no effective filter, fetching and deserializing every ArNS record on-chain (~4k+ accounts) just to find one by name. Replaced with `getArNSRecord` (singular) — a single PDA read. Also parallelized ANT state + write-instance init via `Promise.all`
- Associated names now use a filtered `getArNSRecords` call with the real `processId`, hitting the efficient memcmp path
- Added `arns-record` (singular) cache key invalidation to DomainSettings and dispatchArIOInteraction

## Test plan
- [ ] Purchase a new name without selecting an existing ANT — verify it resolves to the landing page, not the ar.io logo
- [ ] Navigate to `/manage/names/<name>` — verify page loads significantly faster
- [ ] After an ANT interaction (e.g. updating target ID), verify the manage page reflects the change
- [ ] Check associated names display correctly on the manage page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved new ANT purchases by correctly initializing the purchase state for the owner.
  * Preserved existing behavior when reusing an ANT by continuing to associate it with its process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->