### PR TITLE
perf: use single-record lookup in useDomainInfo instead of scanning entire registry

### DIFF
--- a/src/components/forms/DomainSettings/DomainSettings.tsx
+++ b/src/components/forms/DomainSettings/DomainSettings.tsx
@@ -114,6 +114,7 @@ function DomainSettings({
       queryClient.invalidateQueries({
         predicate: ({ queryKey }) =>
           queryKey.includes('arns-records') ||
+          queryKey[0] === 'arns-record' ||
           (queryKey[0] === 'domainInfo' &&
             ((!!domain && queryKey.includes(domain)) ||
               (!!antProcessId && queryKey.includes(antProcessId)))) ||

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -10,14 +10,12 @@ import { isInGracePeriod } from '@src/components/layout/Navbar/NotificationMenu/
 import { useGlobalState } from '@src/state/contexts/GlobalState';
 import { useWalletState } from '@src/state/contexts/WalletState';
 import { ArNSWalletConnector } from '@src/types';
+import { lowerCaseDomain } from '@src/utils';
 import { ANTStateError } from '@src/utils/errors';
-import {
-  buildAntStateQuery,
-  buildArNSRecordsQuery,
-  queryClient,
-} from '@src/utils/network';
+import { buildAntStateQuery, queryClient } from '@src/utils/network';
 import { useQuery } from '@tanstack/react-query';
 import { TransactionEdge } from 'arweave-graphql';
+import { buildArNSRecordQuery } from './useArNSRecord';
 
 export type DomainInfo = {
   arnsRecord?: ArNSNameData;
@@ -75,21 +73,23 @@ export function buildDomainInfoQuery({
     queryFn: async () => {
       const errors: Error[] = [];
 
-      const arnsRecords =
-        domain && arioContract
-          ? await queryClient.fetchQuery(
-              buildArNSRecordsQuery({
-                arioContract,
-                filters: { processId: antId },
-              }),
-            )
-          : undefined;
-
       if (!domain && !antId) {
         throw new Error('No domain or antId provided');
       }
 
-      const record = arnsRecords?.find((r) => r.name === domain);
+      // Fast path: look up the single record by name (one PDA read) instead
+      // of scanning the entire ArNS registry via getArNSRecords.
+      const record =
+        domain && arioContract
+          ? await queryClient
+              .fetchQuery(
+                buildArNSRecordQuery({
+                  name: lowerCaseDomain(domain),
+                  arioContract,
+                }),
+              )
+              .catch(() => null)
+          : undefined;
 
       if (!antId && !record?.processId) {
         throw new Error('No ANT id or record found');
@@ -100,26 +100,38 @@ export function buildDomainInfoQuery({
         throw new Error('No processId found');
       }
 
+      // Kick off ANT state + ANT write-instance fetch in parallel.
       const { buildAnt } = await import('@src/utils/sdk-init');
-      const antProcess = await buildAnt({ wallet, processId });
+      const [state, antProcess] = await Promise.all([
+        queryClient
+          .fetchQuery(buildAntStateQuery({ processId, solana: true } as any))
+          .catch((e) => {
+            console.error(e);
+            errors.push(
+              new ANTStateError(
+                e?.message ?? 'Unknown Error - Unable to fetch ANT state',
+              ),
+            );
+            return null;
+          }),
+        buildAnt({ wallet, processId }),
+      ]);
 
-      const state = await queryClient
-        .fetchQuery(buildAntStateQuery({ processId, solana: true } as any))
-        .catch((e) => {
-          console.error(e);
-          errors.push(
-            new ANTStateError(
-              e?.message ?? 'Unknown Error - Unable to fetch ANT state',
-            ),
-          );
-          return null;
-        });
-
-      const associatedNames = arnsRecords
-        ? arnsRecords
-            .filter((r) => r.processId === processId.toString())
-            .map((r) => r.name)
-        : [];
+      // Associated names: look up all records pointing at this ANT. Now that
+      // we have the real processId the SDK uses a targeted memcmp filter
+      // (one gPA per mint) instead of scanning every record on-chain.
+      let associatedNames: string[] = [];
+      if (arioContract) {
+        try {
+          const { items } = await arioContract.getArNSRecords({
+            filters: { processId },
+          });
+          associatedNames = items.map((r) => r.name);
+        } catch {
+          // Non-critical — the manage page still works without it.
+          associatedNames = domain ? [domain] : [];
+        }
+      }
 
       const {
         Name: name,
@@ -134,7 +146,7 @@ export function buildDomainInfoQuery({
       ).length;
 
       const results: DomainInfo = {
-        arnsRecord: record,
+        arnsRecord: record ?? undefined,
         associatedNames,
         processId,
         antProcess,

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -197,7 +197,7 @@ export default function useDomainInfo({
   return {
     ...query,
     refetch: () => {
-      const keyNames = ['ant', 'ant-info', 'domainInfo'];
+      const keyNames = ['ant', 'ant-info', 'arns-record', 'domainInfo'];
       const keyVals = [antId, domain];
       queryClient.invalidateQueries({
         predicate: (query) =>

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -81,14 +81,12 @@ export function buildDomainInfoQuery({
       // of scanning the entire ArNS registry via getArNSRecords.
       const record =
         domain && arioContract
-          ? await queryClient
-              .fetchQuery(
-                buildArNSRecordQuery({
-                  name: lowerCaseDomain(domain),
-                  arioContract,
-                }),
-              )
-              .catch(() => null)
+          ? await queryClient.fetchQuery(
+              buildArNSRecordQuery({
+                name: lowerCaseDomain(domain),
+                arioContract,
+              }),
+            )
           : undefined;
 
       if (!antId && !record?.processId) {
@@ -198,7 +196,10 @@ export default function useDomainInfo({
     ...query,
     refetch: () => {
       const keyNames = ['ant', 'ant-info', 'arns-record', 'domainInfo'];
-      const keyVals = [antId, domain];
+      const normalizedDomain = domain ? lowerCaseDomain(domain) : undefined;
+      const keyVals = [antId, domain, normalizedDomain].filter(
+        (value): value is string => value !== undefined,
+      );
       queryClient.invalidateQueries({
         predicate: (query) =>
           keyNames.some((name) => query.queryKey.includes(name)) &&

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -1,6 +1,7 @@
 import {
   ANT,
   ARIOWrite,
+  ArNSBuyAntState,
   FundFrom,
   MessageResult,
   PrimaryName,
@@ -198,7 +199,9 @@ export default async function dispatchArIOInteraction({
             ...(existingAntProcessId
               ? { processId: existingAntProcessId }
               : {
-                  antState: createAntStateForOwner(owner.toString()),
+                  antState: createAntStateForOwner(
+                    owner.toString(),
+                  ) as ArNSBuyAntState,
                 }),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
@@ -338,7 +341,7 @@ export default async function dispatchArIOInteraction({
   } finally {
     dispatch({ type: 'setSigning', payload: false });
     // Invalidate balances + every cache that backs the affected name.
-    // `useDomainInfo` internally `fetchQuery`s both `arns-records` and
+    // `useDomainInfo` internally `fetchQuery`s both `arns-record` and
     // `['ant', processId, …]` with long staleTimes, so just busting the
     // outer `domainInfo` key isn't enough — the nested `fetchQuery`s
     // would just return the stale cached values (e.g. an out-of-date
@@ -351,6 +354,7 @@ export default async function dispatchArIOInteraction({
         queryKey.includes('ario-delegated-stake') ||
         queryKey.includes('turbo-credit-balance') ||
         queryKey.includes('arns-records') ||
+        queryKey[0] === 'arns-record' ||
         queryKey.includes('domainInfo') ||
         queryKey[0] === 'ant' ||
         queryKey[0] === 'ant-info' ||


### PR DESCRIPTION
## Summary
- `useDomainInfo` was calling `getArNSRecords()` (plural) with `filters: { processId: undefined }`, which the SDK treats as "no filter" — it fetches **every ArNS record on-chain** (~4k+ accounts via `getProgramAccounts`), deserializes them all, then does a client-side `.find()` by name
- Replaced with `getArNSRecord({ name })` (singular) — a single PDA account read, orders of magnitude faster
- Parallelized ANT state fetch + ANT write-instance init via `Promise.all` (were sequential before)
- Associated names now use a filtered `getArNSRecords({ filters: { processId } })` with the real `processId`, hitting the efficient memcmp path instead of scanning
- Added `arns-record` (singular) cache key to invalidation predicates in DomainSettings and dispatchArIOInteraction

## Test plan
- [ ] Navigate to `/manage/names/<name>` — verify page loads significantly faster
- [ ] Verify all domain settings (target ID, TTL, controllers, etc.) display correctly
- [ ] Verify associated names display correctly
- [ ] After an ANT interaction (e.g. updating target ID), verify the manage page reflects the change
- [ ] Navigate to `/manage/ants/<id>` — verify ANT-by-ID path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain information lookups for faster, more targeted results.
  * Missing domain records are now handled gracefully.
  * Updated cache refresh behavior so individual record details stay current after changes.
  * Improved reliability when loading associated names and ANT state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->