### PR TITLE
release: v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.3.3] - 2026-08-11
+
+### Fixed
+
+- Fixed Turbo credit balance 404 for Solana users by passing wallet `tokenType`
+  explicitly instead of guessing from address format
+- Fixed atomic `buyRecord` defaulting new names' `@` record target to the ar.io
+  logo instead of the landing page (now passes `antState` with `LANDING_PAGE_TXID`)
+- Optimized manage domain page load: replaced full ArNS registry scan (~4k+
+  accounts) with a single PDA record lookup, parallelized ANT state and write
+  instance initialization, and used filtered associated-names query
+
 ## [2.3.2] - 2026-08-11
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/forms/DomainSettings/DomainSettings.tsx
+++ b/src/components/forms/DomainSettings/DomainSettings.tsx
@@ -114,6 +114,7 @@ function DomainSettings({
       queryClient.invalidateQueries({
         predicate: ({ queryKey }) =>
           queryKey.includes('arns-records') ||
+          queryKey[0] === 'arns-record' ||
           (queryKey[0] === 'domainInfo' &&
             ((!!domain && queryKey.includes(domain)) ||
               (!!antProcessId && queryKey.includes(antProcessId)))) ||

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -10,14 +10,12 @@ import { isInGracePeriod } from '@src/components/layout/Navbar/NotificationMenu/
 import { useGlobalState } from '@src/state/contexts/GlobalState';
 import { useWalletState } from '@src/state/contexts/WalletState';
 import { ArNSWalletConnector } from '@src/types';
+import { lowerCaseDomain } from '@src/utils';
 import { ANTStateError } from '@src/utils/errors';
-import {
-  buildAntStateQuery,
-  buildArNSRecordsQuery,
-  queryClient,
-} from '@src/utils/network';
+import { buildAntStateQuery, queryClient } from '@src/utils/network';
 import { useQuery } from '@tanstack/react-query';
 import { TransactionEdge } from 'arweave-graphql';
+import { buildArNSRecordQuery } from './useArNSRecord';
 
 export type DomainInfo = {
   arnsRecord?: ArNSNameData;
@@ -75,21 +73,21 @@ export function buildDomainInfoQuery({
     queryFn: async () => {
       const errors: Error[] = [];
 
-      const arnsRecords =
-        domain && arioContract
-          ? await queryClient.fetchQuery(
-              buildArNSRecordsQuery({
-                arioContract,
-                filters: { processId: antId },
-              }),
-            )
-          : undefined;
-
       if (!domain && !antId) {
         throw new Error('No domain or antId provided');
       }
 
-      const record = arnsRecords?.find((r) => r.name === domain);
+      // Fast path: look up the single record by name (one PDA read) instead
+      // of scanning the entire ArNS registry via getArNSRecords.
+      const record =
+        domain && arioContract
+          ? await queryClient.fetchQuery(
+              buildArNSRecordQuery({
+                name: lowerCaseDomain(domain),
+                arioContract,
+              }),
+            )
+          : undefined;
 
       if (!antId && !record?.processId) {
         throw new Error('No ANT id or record found');
@@ -100,26 +98,38 @@ export function buildDomainInfoQuery({
         throw new Error('No processId found');
       }
 
+      // Kick off ANT state + ANT write-instance fetch in parallel.
       const { buildAnt } = await import('@src/utils/sdk-init');
-      const antProcess = await buildAnt({ wallet, processId });
+      const [state, antProcess] = await Promise.all([
+        queryClient
+          .fetchQuery(buildAntStateQuery({ processId, solana: true } as any))
+          .catch((e) => {
+            console.error(e);
+            errors.push(
+              new ANTStateError(
+                e?.message ?? 'Unknown Error - Unable to fetch ANT state',
+              ),
+            );
+            return null;
+          }),
+        buildAnt({ wallet, processId }),
+      ]);
 
-      const state = await queryClient
-        .fetchQuery(buildAntStateQuery({ processId, solana: true } as any))
-        .catch((e) => {
-          console.error(e);
-          errors.push(
-            new ANTStateError(
-              e?.message ?? 'Unknown Error - Unable to fetch ANT state',
-            ),
-          );
-          return null;
-        });
-
-      const associatedNames = arnsRecords
-        ? arnsRecords
-            .filter((r) => r.processId === processId.toString())
-            .map((r) => r.name)
-        : [];
+      // Associated names: look up all records pointing at this ANT. Now that
+      // we have the real processId the SDK uses a targeted memcmp filter
+      // (one gPA per mint) instead of scanning every record on-chain.
+      let associatedNames: string[] = [];
+      if (arioContract) {
+        try {
+          const { items } = await arioContract.getArNSRecords({
+            filters: { processId },
+          });
+          associatedNames = items.map((r) => r.name);
+        } catch {
+          // Non-critical — the manage page still works without it.
+          associatedNames = domain ? [domain] : [];
+        }
+      }
 
       const {
         Name: name,
@@ -134,7 +144,7 @@ export function buildDomainInfoQuery({
       ).length;
 
       const results: DomainInfo = {
-        arnsRecord: record,
+        arnsRecord: record ?? undefined,
         associatedNames,
         processId,
         antProcess,
@@ -185,8 +195,11 @@ export default function useDomainInfo({
   return {
     ...query,
     refetch: () => {
-      const keyNames = ['ant', 'ant-info', 'domainInfo'];
-      const keyVals = [antId, domain];
+      const keyNames = ['ant', 'ant-info', 'arns-record', 'domainInfo'];
+      const normalizedDomain = domain ? lowerCaseDomain(domain) : undefined;
+      const keyVals = [antId, domain, normalizedDomain].filter(
+        (value): value is string => value !== undefined,
+      );
       queryClient.invalidateQueries({
         predicate: (query) =>
           keyNames.some((name) => query.queryKey.includes(name)) &&

--- a/src/hooks/useTurboArNSClient.tsx
+++ b/src/hooks/useTurboArNSClient.tsx
@@ -20,6 +20,7 @@ export function useTurboArNSClient() {
     }
     return new TurboArNSClient({
       walletAddress: walletAddress?.toString(),
+      tokenType: wallet?.tokenType,
       paymentUrl: turboNetwork.PAYMENT_URL,
       stripe,
     });

--- a/src/services/turbo/TurboArNSClient.ts
+++ b/src/services/turbo/TurboArNSClient.ts
@@ -39,6 +39,8 @@ export interface TurboArNSClientConfig {
   // back-compat; Solana support requires the Turbo payment service update.
   signer?: any;
   walletAddress?: string;
+  /** Explicit token type from the connected wallet — avoids fragile address-format guessing. */
+  tokenType?: TokenType;
   stripe: Stripe;
   ao?: any;
 }
@@ -138,6 +140,7 @@ export class TurboArNSClient {
     walletsUrl = NETWORK_DEFAULTS.TURBO.WALLETS_URL,
     signer,
     walletAddress,
+    tokenType,
     stripe,
     ao = connect(NETWORK_DEFAULTS.AO.ARIO),
   }: TurboArNSClientConfig) {
@@ -149,6 +152,17 @@ export class TurboArNSClient {
     this.walletAddress = walletAddress;
     this.stripe = stripe;
     this.ao = ao;
+    // Prefer the explicit tokenType from the wallet connector; fall back to
+    // address-format detection only when the caller didn't supply one.
+    const resolvedToken: TokenType | undefined =
+      tokenType ??
+      (isArweaveTransactionID(this.walletAddress)
+        ? 'arweave'
+        : isEthAddress(this.walletAddress ?? '')
+          ? 'ethereum'
+          : isValidSolanaAddress(this.walletAddress ?? '')
+            ? 'solana'
+            : undefined);
     this.turboUploader = TurboFactory.unauthenticated({
       paymentServiceConfig: {
         url: this.paymentUrl,
@@ -157,13 +171,7 @@ export class TurboArNSClient {
         url: this.uploadUrl,
       },
       gatewayUrl: this.gatewayUrl,
-      token: isArweaveTransactionID(this.walletAddress)
-        ? 'arweave'
-        : isEthAddress(this.walletAddress ?? '')
-          ? 'ethereum'
-          : isValidSolanaAddress(this.walletAddress ?? '')
-            ? 'solana'
-            : undefined,
+      token: resolvedToken,
     });
     this.arioProcessId =
       this.paymentUrl === devPaymentServiceFqdn

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -197,7 +197,9 @@ export default async function dispatchArIOInteraction({
             years,
             ...(existingAntProcessId
               ? { processId: existingAntProcessId }
-              : {}),
+              : {
+                  antState: createAntStateForOwner(owner.toString()),
+                }),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
             paidBy,

--- a/src/state/actions/dispatchArIOInteraction.ts
+++ b/src/state/actions/dispatchArIOInteraction.ts
@@ -1,6 +1,7 @@
 import {
   ANT,
   ARIOWrite,
+  ArNSBuyAntState,
   FundFrom,
   MessageResult,
   PrimaryName,
@@ -198,7 +199,9 @@ export default async function dispatchArIOInteraction({
             ...(existingAntProcessId
               ? { processId: existingAntProcessId }
               : {
-                  antState: createAntStateForOwner(owner.toString()),
+                  antState: createAntStateForOwner(
+                    owner.toString(),
+                  ) as ArNSBuyAntState,
                 }),
             fundFrom: originalFundFrom,
             referrer: APP_NAME,
@@ -338,7 +341,7 @@ export default async function dispatchArIOInteraction({
   } finally {
     dispatch({ type: 'setSigning', payload: false });
     // Invalidate balances + every cache that backs the affected name.
-    // `useDomainInfo` internally `fetchQuery`s both `arns-records` and
+    // `useDomainInfo` internally `fetchQuery`s both `arns-record` and
     // `['ant', processId, …]` with long staleTimes, so just busting the
     // outer `domainInfo` key isn't enough — the nested `fetchQuery`s
     // would just return the stale cached values (e.g. an out-of-date
@@ -351,6 +354,7 @@ export default async function dispatchArIOInteraction({
         queryKey.includes('ario-delegated-stake') ||
         queryKey.includes('turbo-credit-balance') ||
         queryKey.includes('arns-records') ||
+        queryKey[0] === 'arns-record' ||
         queryKey.includes('domainInfo') ||
         queryKey[0] === 'ant' ||
         queryKey[0] === 'ant-info' ||


### PR DESCRIPTION
## Summary
- **Fix**: Turbo credit balance 404 for Solana users — pass wallet `tokenType` explicitly instead of address-format guessing
- **Fix**: Atomic `buyRecord` defaulting `@` record target to ar.io logo instead of landing page — now passes `antState` with `LANDING_PAGE_TXID`
- **Perf**: Manage domain page — replaced full ArNS registry scan (~4k+ accounts) with single PDA lookup, parallelized ANT state + write instance init, filtered associated-names query

## Test plan
- [ ] Verify Turbo credit balance loads without 404 for Solana users
- [ ] Purchase a new name and verify it resolves to landing page, not ar.io logo
- [ ] Navigate to manage domain page and verify fast load
- [ ] Verify associated names, domain settings, and undernames display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)