### PR TITLE
release: v2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.3.4] - 2026-08-11
+
+### Fixed
+
+- Fixed lease expiry dates showing as 1970 and status as "Expired" on manage
+  page — SDK's `getArNSRecord` (singular) returns timestamps in seconds while
+  the app expects milliseconds
+- Fixed Turbo credit balance 404 for Solana users by passing wallet `tokenType`
+  explicitly instead of guessing from address format
+- Fixed atomic `buyRecord` defaulting new names' `@` record target to the ar.io
+  logo instead of the landing page (now passes `antState` with `LANDING_PAGE_TXID`)
+- Optimized manage domain page load: replaced full ArNS registry scan (~4k+
+  accounts) with a single PDA record lookup, parallelized ANT state and write
+  instance initialization, and used filtered associated-names query
+
 ## [2.3.3] - 2026-08-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "2.3.3",
+  "version": "2.3.4",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -79,7 +79,11 @@ export function buildDomainInfoQuery({
 
       // Fast path: look up the single record by name (one PDA read) instead
       // of scanning the entire ArNS registry via getArNSRecords.
-      const record =
+      // NOTE: SDK bug — `getArNSRecord` (singular) returns timestamps in
+      // seconds (raw from on-chain), while `getArNSRecords` (plural)
+      // converts them to milliseconds via `secToMs`. Normalise here so
+      // the rest of the app can assume milliseconds.
+      const rawRecord =
         domain && arioContract
           ? await queryClient.fetchQuery(
               buildArNSRecordQuery({
@@ -88,6 +92,15 @@ export function buildDomainInfoQuery({
               }),
             )
           : undefined;
+      const record = rawRecord
+        ? {
+            ...rawRecord,
+            startTimestamp: rawRecord.startTimestamp * 1000,
+            ...('endTimestamp' in rawRecord && rawRecord.endTimestamp
+              ? { endTimestamp: rawRecord.endTimestamp * 1000 }
+              : {}),
+          }
+        : undefined;
 
       if (!antId && !record?.processId) {
         throw new Error('No ANT id or record found');


### PR DESCRIPTION
## Summary
- **Fix**: Lease expiry dates showing as 1970 / "Expired" on manage page — SDK's `getArNSRecord` (singular) returns timestamps in seconds while the app expects milliseconds
- Includes all v2.3.3 fixes (Turbo balance 404, atomic buy target ID, manage page perf)

## Test plan
- [ ] Navigate to `/manage/names/whitepaper` — verify expiry date is correct (not 1970) and status is "Active"
- [ ] Check other leased names show correct expiry dates
- [ ] Verify permabuy names still show "Permanent" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)