### PR TITLE
release: v2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## [2.3.4] - 2026-08-11
+## [2.3.5] - 2026-08-11
 
 ### Changed
 
@@ -18,6 +18,11 @@ and this project adheres to
 
 - Fixed lease expiry dates showing as 1970 and status as "Expired" on manage
   page (resolved upstream in SDK 4.1.2)
+
+## [2.3.4] - 2026-08-11
+
+### Fixed
+
 - Fixed Turbo credit balance 404 for Solana users by passing wallet `tokenType`
   explicitly instead of guessing from address format
 - Fixed atomic `buyRecord` defaulting new names' `@` record target to the ar.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to
 
 ## [2.3.4] - 2026-08-11
 
+### Changed
+
+- Upgraded `@ar.io/sdk` to 4.1.2 (fixes `getArNSRecord` timestamp conversion)
+
 ### Fixed
 
 - Fixed lease expiry dates showing as 1970 and status as "Expired" on manage
-  page — SDK's `getArNSRecord` (singular) returns timestamps in seconds while
-  the app expects milliseconds
+  page (resolved upstream in SDK 4.1.2)
 - Fixed Turbo credit balance 404 for Solana users by passing wallet `tokenType`
   explicitly instead of guessing from address format
 - Fixed atomic `buyRecord` defaulting new names' `@` record target to the ar.io

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arns-vite-react",
   "private": true,
-  "version": "2.3.4",
+  "version": "2.3.5",
   "homepage": ".",
   "scripts": {
     "build": "yarn clean && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
-    "@ar.io/sdk": "4.1.1",
+    "@ar.io/sdk": "4.1.2",
     "@ardrive/turbo-sdk": "1.39.2",
     "@permaweb/aoconnect": "0.0.69",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/src/hooks/useDomainInfo.tsx
+++ b/src/hooks/useDomainInfo.tsx
@@ -79,11 +79,7 @@ export function buildDomainInfoQuery({
 
       // Fast path: look up the single record by name (one PDA read) instead
       // of scanning the entire ArNS registry via getArNSRecords.
-      // NOTE: SDK bug — `getArNSRecord` (singular) returns timestamps in
-      // seconds (raw from on-chain), while `getArNSRecords` (plural)
-      // converts them to milliseconds via `secToMs`. Normalise here so
-      // the rest of the app can assume milliseconds.
-      const rawRecord =
+      const record =
         domain && arioContract
           ? await queryClient.fetchQuery(
               buildArNSRecordQuery({
@@ -92,15 +88,6 @@ export function buildDomainInfoQuery({
               }),
             )
           : undefined;
-      const record = rawRecord
-        ? {
-            ...rawRecord,
-            startTimestamp: rawRecord.startTimestamp * 1000,
-            ...('endTimestamp' in rawRecord && rawRecord.endTimestamp
-              ? { endTimestamp: rawRecord.endTimestamp * 1000 }
-              : {}),
-          }
-        : undefined;
 
       if (!antId && !record?.processId) {
         throw new Error('No ANT id or record found');

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,10 +131,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.1.tgz#d9932b47c308d45e8b8315150cc2bf5afd55b4e1"
-  integrity sha512-a0mg6emlmWpzuV2OrVnBikTO7tkjyiiIzK3nbM/wH6CG+YQEcN2+S8N+m0HlixjeOfK/G1rOEnt82NO1vSXF/w==
+"@ar.io/sdk@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.2.tgz#421cf300112e6698b53d000eaad45237437e7d53"
+  integrity sha512-4AyS67lkKa62L6BAWrNbXx3S1GG/AKWeMNZCGkqpkwwKldLGLyq3ZQrylku2bcSJKqRKL/SmYS76OPqIC6o3aQ==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
## Summary

- Upgraded `@ar.io/sdk` to 4.1.2 which fixes `getArNSRecord` timestamp conversion (seconds → milliseconds)
- Removes the temporary timestamp workaround in `useDomainInfo.tsx`
- Fixes lease expiry dates showing as 1970 and status as "Expired" on the manage page

## Changes

- `package.json` / `yarn.lock`: `@ar.io/sdk` 4.1.1 → 4.1.2
- `src/hooks/useDomainInfo.tsx`: Removed manual `* 1000` timestamp workaround (now handled by SDK)
- `CHANGELOG.md`: Added v2.3.5 release notes

## Test plan

- [ ] Verify leased names show correct expiry dates (not 1970) on manage page
- [ ] Verify leased names show correct status (not "Expired") on manage page
- [ ] Verify permabuy names display correctly on manage page
- [ ] Smoke test name registration flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)